### PR TITLE
chore(new): Add Spinnaker templates for pod level experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,29 +26,49 @@ job:
   preconfigured:
     kubernetes:
       - label: Pod-Delete-Chaos
-        type: ChaosExperiment
+        type: PodDeleteChaosExperiment
         description: Kill an application pod
         cloudProvider: kubernetes
         account: spinnaker
         credentials: spinnaker
-        application: hello
+        application: litmuschaos
         waitForCompletion: true
         parameters:
+          - name: INSTALL_LITMUS
+            label: install litmus
+            description: Install litmus if it is not already installed
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "false"           
           - name: APPLICATION_NAMESPACE
             label: Namespace of AUT
             description: Namespace where chaos will occur
-            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
             defaultValue: "spinnaker"
           - name: APPLICATION_LABEL
             label: Label of AUT
             description: Label by which app is filtered
-            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
             defaultValue: "name=hello"
           - name: CHAOS_DURATION
             label: Chaos duration
-            description: The time duration for chaos insertion (in sec)
-            mapping: manifest.spec.template.spec.containers[0].env[2].value
-            defaultValue: "30"
+            description: The time duration for chaos insertion (in sec)	
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            defaultValue: "30" 
+          - name: CHAOS_INTERVAL
+            label: Chaos interval
+            description: Time interval b/w two successive pod deletes (in sec)	
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            defaultValue: "10"   
+          - name: FORCE_DELETE
+            label: force
+            description: To delete pod forcefully	
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            defaultValue: "false"   
+          - name: UNINSTALL_LITMUS_ON_COMPLETION
+            label: uninstall litmus
+            description: Uninstall litmus if no more test to run
+            mapping: manifest.spec.template.spec.containers[0].env[6].value
+            defaultValue: "false"                                       
         manifest:
           apiVersion: batch/v1
           kind: Job
@@ -59,20 +79,30 @@ job:
             template:
               spec:
                 restartPolicy: Never
-                containers:
+                containers: 
                   - name: run-pod-delete-chaos
                     image: mayadataio/chaos-ci-lib:ci
                     env:
+                      - name: INSTALL_LITMUS
+                        value: "$(INSTALL_LITMUS)"                    
                       - name: APP_NS
                         value: $(APPLICATION_NAMESPACE)
                       - name: APP_LABEL
                         value: $(APPLICATION_LABEL)
                       - name: TOTAL_CHAOS_DURATION
                         value: "$(CHAOS_DURATION)"
+                      - name: CHAOS_INTERVAL
+                        value: "$(CHAOS_INTERVAL)"
+                      - name: FORCE
+                        value: "$(FORCE_DELETE)"
+                      - name: UNINSTALL_LITMUS
+                        value: "$(UNINSTALL_LITMUS_ON_COMPLETION)"                           
+                      - name: EXPERIMENT_NAME
+                        value: "pod-delete"                                                
                     command: ["/bin/bash"]
                     args:
-                    - -c
-                    - ./pod-delete
+                    - -c 
+                    - ./experiment_entrypoint.sh
 ```
 
 ## Updating the Custom Job Template

--- a/templates/experiments/container-kill.yml
+++ b/templates/experiments/container-kill.yml
@@ -1,0 +1,73 @@
+---
+job:
+  preconfigured:
+    kubernetes:
+      - label: Container-Kill-Chaos
+        type: ContainerKillChaosExperiment
+        description: Kill one container in the application pod
+        cloudProvider: kubernetes
+        account: spinnaker
+        credentials: spinnaker
+        application: hello
+        waitForCompletion: true
+        parameters:
+          - name: APPLICATION_NAMESPACE
+            label: Namespace of AUT
+            description: Namespace where chaos will occur
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "spinnaker"
+          - name: APPLICATION_LABEL
+            label: Label of AUT
+            description: Label by which app is filtered
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            defaultValue: "name=hello"
+          - name: CHAOS_DURATION
+            label: Chaos duration
+            description: The time duration for chaos insertion (in sec)	
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            defaultValue: "30"
+          - name: CHAOS_INTERVAL
+            label: Chaos interval
+            description: Time interval b/w two successive container kill (in sec)	
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            defaultValue: "10"            
+          - name: CONTAINER_RUNTIME
+            label: Container runtime
+            description: The container runtime interface for the cluster
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            defaultValue: "containerd"
+          - name: TARGET_CONTAINER
+            label: Target Container
+            description: The container to be killed inside the pod
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            defaultValue: "hello"
+        manifest:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+              name: run-container-kill-chaos
+          spec:
+            backoffLimit: 0
+            template:
+              spec:
+                restartPolicy: Never
+                containers: 
+                  - name: run-container-kill-chaos
+                    image: mayadataio/chaos-ci-lib:ci
+                    env:
+                      - name: APP_NS
+                        value: $(APPLICATION_NAMESPACE)
+                      - name: APP_LABEL
+                        value: $(APPLICATION_LABEL)
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "$(CHAOS_DURATION)"        
+                      - name: CHAOS_INTERVAL
+                        value: "$(CHAOS_INTERVAL)"    
+                      - name: CONTAINER_RUNTIME
+                        value: "$(CONTAINER_RUNTIME)"   
+                      - name: TARGET_CONTAINER
+                        value: "$(TARGET_CONTAINER)"   
+                    command: ["/bin/bash"]
+                    args:
+                    - -c 
+                    - ./container-kill

--- a/templates/experiments/container-kill.yml
+++ b/templates/experiments/container-kill.yml
@@ -8,7 +8,7 @@ job:
         cloudProvider: kubernetes
         account: spinnaker
         credentials: spinnaker
-        application: hello
+        application: litmuschaos
         waitForCompletion: true
         parameters:
           - name: INSTALL_LITMUS
@@ -41,11 +41,21 @@ job:
             description: The container runtime interface for the cluster
             mapping: manifest.spec.template.spec.containers[0].env[5].value
             defaultValue: "containerd"
+          - name: SOCKET_PATH
+            label: socket path
+            description: Provide the socket file path, applicable only for containerd runtime
+            mapping: manifest.spec.template.spec.containers[0].env[6].value
+            defaultValue: "'/run/containerd/containerd.sock'"            
           - name: TARGET_CONTAINER
             label: Target Container
             description: The container to be killed inside the pod
-            mapping: manifest.spec.template.spec.containers[0].env[6].value
+            mapping: manifest.spec.template.spec.containers[0].env[7].value
             defaultValue: "hello"
+          - name: UNINSTALL_LITMUS_ON_COMPLETION
+            label: uninstall litmus
+            description: Uninstall litmus if no more test to run
+            mapping: manifest.spec.template.spec.containers[0].env[8].value
+            defaultValue: "false"      
         manifest:
           apiVersion: batch/v1
           kind: Job
@@ -74,6 +84,10 @@ job:
                         value: "$(CONTAINER_RUNTIME)"   
                       - name: TARGET_CONTAINER
                         value: "$(TARGET_CONTAINER)"
+                      - name: SOCKET_PATH
+                        value: "$(SOCKET_PATH)"                        
+                      - name: UNINSTALL_LITMUS
+                        value: "$(UNINSTALL_LITMUS_ON_COMPLETION)"                          
                       - name: EXPERIMENT_NAME
                         value: "container-kill"                        
                     command: ["/bin/bash"]

--- a/templates/experiments/container-kill.yml
+++ b/templates/experiments/container-kill.yml
@@ -11,35 +11,40 @@ job:
         application: hello
         waitForCompletion: true
         parameters:
+          - name: INSTALL_LITMUS
+            label: install litmus
+            description: Install litmus if it is not already installed
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "false"        
           - name: APPLICATION_NAMESPACE
             label: Namespace of AUT
             description: Namespace where chaos will occur
-            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
             defaultValue: "spinnaker"
           - name: APPLICATION_LABEL
             label: Label of AUT
             description: Label by which app is filtered
-            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
             defaultValue: "name=hello"
           - name: CHAOS_DURATION
             label: Chaos duration
             description: The time duration for chaos insertion (in sec)	
-            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
             defaultValue: "30"
           - name: CHAOS_INTERVAL
             label: Chaos interval
             description: Time interval b/w two successive container kill (in sec)	
-            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "10"            
           - name: CONTAINER_RUNTIME
             label: Container runtime
             description: The container runtime interface for the cluster
-            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
             defaultValue: "containerd"
           - name: TARGET_CONTAINER
             label: Target Container
             description: The container to be killed inside the pod
-            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            mapping: manifest.spec.template.spec.containers[0].env[6].value
             defaultValue: "hello"
         manifest:
           apiVersion: batch/v1
@@ -55,6 +60,8 @@ job:
                   - name: run-container-kill-chaos
                     image: mayadataio/chaos-ci-lib:ci
                     env:
+                      - name: INSTALL_LITMUS
+                        value: "$(INSTALL_LITMUS)"                    
                       - name: APP_NS
                         value: $(APPLICATION_NAMESPACE)
                       - name: APP_LABEL
@@ -66,8 +73,10 @@ job:
                       - name: CONTAINER_RUNTIME
                         value: "$(CONTAINER_RUNTIME)"   
                       - name: TARGET_CONTAINER
-                        value: "$(TARGET_CONTAINER)"   
+                        value: "$(TARGET_CONTAINER)"
+                      - name: EXPERIMENT_NAME
+                        value: "container-kill"                        
                     command: ["/bin/bash"]
                     args:
                     - -c 
-                    - ./container-kill
+                    - ./experiment_entrypoint.sh

--- a/templates/experiments/disk-fill.yml
+++ b/templates/experiments/disk-fill.yml
@@ -8,7 +8,7 @@ job:
         cloudProvider: kubernetes
         account: spinnaker
         credentials: spinnaker
-        application: hello
+        application: litmuschaos
         waitForCompletion: true
         parameters:
           - name: INSTALL_LITMUS
@@ -40,7 +40,12 @@ job:
             label: Fill percentage
             description: Percentage to fill the Ephemeral storage limit
             mapping: manifest.spec.template.spec.containers[0].env[5].value
-            defaultValue: "hello"            
+            defaultValue: "hello"
+          - name: UNINSTALL_LITMUS_ON_COMPLETION
+            label: uninstall litmus
+            description: Uninstall litmus if no more test to run
+            mapping: manifest.spec.template.spec.containers[0].env[6].value
+            defaultValue: "false"                     
         manifest:
           apiVersion: batch/v1
           kind: Job
@@ -67,6 +72,8 @@ job:
                         value: "$(TARGET_CONTAINER)"
                       - name: FILL_PERCENTAGE
                         value: "$(FILL_PERCENTAGE)"
+                      - name: UNINSTALL_LITMUS
+                        value: "$(UNINSTALL_LITMUS_ON_COMPLETION)"                           
                       - name: EXPERIMENT_NAME
                         value: "disk-fill"                                                   
                     command: ["/bin/bash"]

--- a/templates/experiments/disk-fill.yml
+++ b/templates/experiments/disk-fill.yml
@@ -1,0 +1,66 @@
+---
+job:
+  preconfigured:
+    kubernetes:
+      - label: Disk-Fill-Chaos
+        type: DiskFillChaosExperiment
+        description: Fill up Ephemeral Storage of a Pod
+        cloudProvider: kubernetes
+        account: spinnaker
+        credentials: spinnaker
+        application: hello
+        waitForCompletion: true
+        parameters:
+          - name: APPLICATION_NAMESPACE
+            label: Namespace of AUT
+            description: Namespace where chaos will occur
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "spinnaker"
+          - name: APPLICATION_LABEL
+            label: Label of AUT
+            description: Label by which app is filtered
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            defaultValue: "name=hello"
+          - name: CHAOS_DURATION
+            label: Chaos duration
+            description: The time duration for chaos insertion (in sec)	
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            defaultValue: "30"            
+          - name: TARGET_CONTAINER
+            label: Target Container
+            description: Name of container which is subjected to disk-fill
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            defaultValue: "hello"
+          - name: FILL_PERCENTAGE
+            label: Fill percentage
+            description: Percentage to fill the Ephemeral storage limit
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            defaultValue: "hello"            
+        manifest:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+              name: run-disk-fill-chaos
+          spec:
+            backoffLimit: 0
+            template:
+              spec:
+                restartPolicy: Never
+                containers: 
+                  - name: run-disk-fill-chaos
+                    image: mayadataio/chaos-ci-lib:ci
+                    env:
+                      - name: APP_NS
+                        value: $(APPLICATION_NAMESPACE)
+                      - name: APP_LABEL
+                        value: $(APPLICATION_LABEL)
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "$(CHAOS_DURATION)"
+                      - name: TARGET_CONTAINER
+                        value: "$(TARGET_CONTAINER)"
+                      - name: FILL_PERCENTAGE
+                        value: "$(FILL_PERCENTAGE)"                         
+                    command: ["/bin/bash"]
+                    args:
+                    - -c 
+                    - ./disk-fill

--- a/templates/experiments/disk-fill.yml
+++ b/templates/experiments/disk-fill.yml
@@ -11,30 +11,35 @@ job:
         application: hello
         waitForCompletion: true
         parameters:
+          - name: INSTALL_LITMUS
+            label: install litmus
+            description: Install litmus if it is not already installed
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "false"          
           - name: APPLICATION_NAMESPACE
             label: Namespace of AUT
             description: Namespace where chaos will occur
-            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
             defaultValue: "spinnaker"
           - name: APPLICATION_LABEL
             label: Label of AUT
             description: Label by which app is filtered
-            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
             defaultValue: "name=hello"
           - name: CHAOS_DURATION
             label: Chaos duration
             description: The time duration for chaos insertion (in sec)	
-            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
             defaultValue: "30"            
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of container which is subjected to disk-fill
-            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "hello"
           - name: FILL_PERCENTAGE
             label: Fill percentage
             description: Percentage to fill the Ephemeral storage limit
-            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
             defaultValue: "hello"            
         manifest:
           apiVersion: batch/v1
@@ -50,6 +55,8 @@ job:
                   - name: run-disk-fill-chaos
                     image: mayadataio/chaos-ci-lib:ci
                     env:
+                      - name: INSTALL_LITMUS
+                        value: "$(INSTALL_LITMUS)"                       
                       - name: APP_NS
                         value: $(APPLICATION_NAMESPACE)
                       - name: APP_LABEL
@@ -59,8 +66,10 @@ job:
                       - name: TARGET_CONTAINER
                         value: "$(TARGET_CONTAINER)"
                       - name: FILL_PERCENTAGE
-                        value: "$(FILL_PERCENTAGE)"                         
+                        value: "$(FILL_PERCENTAGE)"
+                      - name: EXPERIMENT_NAME
+                        value: "disk-fill"                                                   
                     command: ["/bin/bash"]
                     args:
                     - -c 
-                    - ./disk-fill
+                    - ./experiment_entrypoint.sh

--- a/templates/experiments/pod-cpu-hog.yml
+++ b/templates/experiments/pod-cpu-hog.yml
@@ -11,30 +11,35 @@ job:
         application: hello
         waitForCompletion: true
         parameters:
+          - name: INSTALL_LITMUS
+            label: install litmus
+            description: Install litmus if it is not already installed
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "false"          
           - name: APPLICATION_NAMESPACE
             label: Namespace of AUT
             description: Namespace where chaos will occur
-            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
             defaultValue: "spinnaker"
           - name: APPLICATION_LABEL
             label: Label of AUT
             description: Label by which app is filtered
-            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
             defaultValue: "name=hello"
           - name: CHAOS_DURATION
             label: Chaos duration
             description: The time duration for chaos insertion (in sec)	
-            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
             defaultValue: "30"
           - name: NUMBER_OF_CPU_CORES
             label: Cores of CPU
             description: Number of the cpu cores subjected to CPU stress	
-            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "1"
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of the container subjected to CPU stress
-            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
             defaultValue: "hello"
         manifest:
           apiVersion: batch/v1
@@ -50,6 +55,8 @@ job:
                   - name: run-pod-cpu-hog-chaos
                     image: mayadataio/chaos-ci-lib:ci
                     env:
+                      - name: INSTALL_LITMUS
+                        value: "$(INSTALL_LITMUS)"                    
                       - name: APP_NS
                         value: $(APPLICATION_NAMESPACE)
                       - name: APP_LABEL
@@ -59,8 +66,10 @@ job:
                       - name: CPU_CORES
                         value: "$(NUMBER_OF_CPU_CORES)"    
                       - name: TARGET_CONTAINER
-                        value: "$(TARGET_CONTAINER)"   
+                        value: "$(TARGET_CONTAINER)"
+                      - name: EXPERIMENT_NAME
+                        value: "pod-cpu-hog"                          
                     command: ["/bin/bash"]
                     args:
                     - -c 
-                    - ./pod-cpu-hog
+                    - ./experiment_entrypoint.sh

--- a/templates/experiments/pod-cpu-hog.yml
+++ b/templates/experiments/pod-cpu-hog.yml
@@ -1,0 +1,66 @@
+---
+job:
+  preconfigured:
+    kubernetes:
+      - label: Pod-CPU-Hog-Chaos
+        type: PodCPUHogChaosExperiment
+        description: Consume CPU resources on the application container	
+        cloudProvider: kubernetes
+        account: spinnaker
+        credentials: spinnaker
+        application: hello
+        waitForCompletion: true
+        parameters:
+          - name: APPLICATION_NAMESPACE
+            label: Namespace of AUT
+            description: Namespace where chaos will occur
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "spinnaker"
+          - name: APPLICATION_LABEL
+            label: Label of AUT
+            description: Label by which app is filtered
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            defaultValue: "name=hello"
+          - name: CHAOS_DURATION
+            label: Chaos duration
+            description: The time duration for chaos insertion (in sec)	
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            defaultValue: "30"
+          - name: NUMBER_OF_CPU_CORES
+            label: Cores of CPU
+            description: Number of the cpu cores subjected to CPU stress	
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            defaultValue: "1"
+          - name: TARGET_CONTAINER
+            label: Target Container
+            description: Name of the container subjected to CPU stress
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            defaultValue: "hello"
+        manifest:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+              name: run-pod-cpu-hog-chaos
+          spec:
+            backoffLimit: 0
+            template:
+              spec:
+                restartPolicy: Never
+                containers: 
+                  - name: run-pod-cpu-hog-chaos
+                    image: mayadataio/chaos-ci-lib:ci
+                    env:
+                      - name: APP_NS
+                        value: $(APPLICATION_NAMESPACE)
+                      - name: APP_LABEL
+                        value: $(APPLICATION_LABEL)
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "$(CHAOS_DURATION)"        
+                      - name: CPU_CORES
+                        value: "$(NUMBER_OF_CPU_CORES)"    
+                      - name: TARGET_CONTAINER
+                        value: "$(TARGET_CONTAINER)"   
+                    command: ["/bin/bash"]
+                    args:
+                    - -c 
+                    - ./pod-cpu-hog

--- a/templates/experiments/pod-cpu-hog.yml
+++ b/templates/experiments/pod-cpu-hog.yml
@@ -8,7 +8,7 @@ job:
         cloudProvider: kubernetes
         account: spinnaker
         credentials: spinnaker
-        application: hello
+        application: litmuschaos
         waitForCompletion: true
         parameters:
           - name: INSTALL_LITMUS
@@ -36,11 +36,26 @@ job:
             description: Number of the cpu cores subjected to CPU stress	
             mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "1"
+          - name: CHAOS_INJECT_COMMAND
+            label: chaos inject command
+            description: Command to inject cpu chaos 	
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            defaultValue: "'md5sum /dev/zero'"    
+          - name: CHAOS_KILL_COMMAND
+            label: chaos kill command
+            description: Kills the chaos process inside the target container	
+            mapping: manifest.spec.template.spec.containers[0].env[6].value
+            defaultValue: "\"kill -9 $(ps afx | grep \"[md5sum] /dev/zero\" | awk '{print$1}' | tr '\n' ' ')\""
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of the container subjected to CPU stress
-            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            mapping: manifest.spec.template.spec.containers[0].env[7].value
             defaultValue: "hello"
+          - name: UNINSTALL_LITMUS_ON_COMPLETION
+            label: uninstall litmus
+            description: Uninstall litmus if no more test to run
+            mapping: manifest.spec.template.spec.containers[0].env[8].value
+            defaultValue: "false"             
         manifest:
           apiVersion: batch/v1
           kind: Job
@@ -64,9 +79,15 @@ job:
                       - name: TOTAL_CHAOS_DURATION
                         value: "$(CHAOS_DURATION)"        
                       - name: CPU_CORES
-                        value: "$(NUMBER_OF_CPU_CORES)"    
+                        value: "$(NUMBER_OF_CPU_CORES)"   
+                      - name: CHAOS_INJECT_COMMAND
+                        value: "$(CHAOS_INJECT_COMMAND)"   
+                      - name: CHAOS_KILL_COMMAND
+                        value: "$(CHAOS_KILL_COMMAND)"   
                       - name: TARGET_CONTAINER
                         value: "$(TARGET_CONTAINER)"
+                      - name: UNINSTALL_LITMUS
+                        value: "$(UNINSTALL_LITMUS_ON_COMPLETION)"                           
                       - name: EXPERIMENT_NAME
                         value: "pod-cpu-hog"                          
                     command: ["/bin/bash"]

--- a/templates/experiments/pod-delete.yml
+++ b/templates/experiments/pod-delete.yml
@@ -3,7 +3,7 @@ job:
   preconfigured:
     kubernetes:
       - label: Pod-Delete-Chaos
-        type: ChaosExperiment
+        type: PodDeleteChaosExperiment
         description: Kill an application pod
         cloudProvider: kubernetes
         account: spinnaker
@@ -11,20 +11,25 @@ job:
         application: hello
         waitForCompletion: true
         parameters:
+          - name: INSTALL_LITMUS
+            label: install litmus
+            description: Install litmus if it is not already installed
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "false"           
           - name: APPLICATION_NAMESPACE
             label: Namespace of AUT
             description: Namespace where chaos will occur
-            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
             defaultValue: "spinnaker"
           - name: APPLICATION_LABEL
             label: Label of AUT
             description: Label by which app is filtered
-            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
             defaultValue: "name=hello"
           - name: CHAOS_DURATION
             label: Chaos duration
             description: The time duration for chaos insertion (in sec)	
-            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
             defaultValue: "30"                           
         manifest:
           apiVersion: batch/v1
@@ -40,13 +45,17 @@ job:
                   - name: run-pod-delete-chaos
                     image: mayadataio/chaos-ci-lib:ci
                     env:
+                      - name: INSTALL_LITMUS
+                        value: "$(INSTALL_LITMUS)"                    
                       - name: APP_NS
                         value: $(APPLICATION_NAMESPACE)
                       - name: APP_LABEL
                         value: $(APPLICATION_LABEL)
                       - name: TOTAL_CHAOS_DURATION
-                        value: "$(CHAOS_DURATION)"                        
+                        value: "$(CHAOS_DURATION)"
+                      - name: EXPERIMENT_NAME
+                        value: "pod-delete"                                                
                     command: ["/bin/bash"]
                     args:
                     - -c 
-                    - ./pod-delete
+                    - ./experiment_entrypoint.sh

--- a/templates/experiments/pod-delete.yml
+++ b/templates/experiments/pod-delete.yml
@@ -8,7 +8,7 @@ job:
         cloudProvider: kubernetes
         account: spinnaker
         credentials: spinnaker
-        application: hello
+        application: litmuschaos
         waitForCompletion: true
         parameters:
           - name: INSTALL_LITMUS
@@ -30,7 +30,22 @@ job:
             label: Chaos duration
             description: The time duration for chaos insertion (in sec)	
             mapping: manifest.spec.template.spec.containers[0].env[3].value
-            defaultValue: "30"                           
+            defaultValue: "30" 
+          - name: CHAOS_INTERVAL
+            label: Chaos interval
+            description: Time interval b/w two successive pod deletes (in sec)	
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            defaultValue: "10"   
+          - name: FORCE_DELETE
+            label: force
+            description: To delete pod forcefully	
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            defaultValue: "false"   
+          - name: UNINSTALL_LITMUS_ON_COMPLETION
+            label: uninstall litmus
+            description: Uninstall litmus if no more test to run
+            mapping: manifest.spec.template.spec.containers[0].env[6].value
+            defaultValue: "false"                                       
         manifest:
           apiVersion: batch/v1
           kind: Job
@@ -53,6 +68,12 @@ job:
                         value: $(APPLICATION_LABEL)
                       - name: TOTAL_CHAOS_DURATION
                         value: "$(CHAOS_DURATION)"
+                      - name: CHAOS_INTERVAL
+                        value: "$(CHAOS_INTERVAL)"
+                      - name: FORCE
+                        value: "$(FORCE_DELETE)"
+                      - name: UNINSTALL_LITMUS
+                        value: "$(UNINSTALL_LITMUS_ON_COMPLETION)"                           
                       - name: EXPERIMENT_NAME
                         value: "pod-delete"                                                
                     command: ["/bin/bash"]

--- a/templates/experiments/pod-memory-hog.yml
+++ b/templates/experiments/pod-memory-hog.yml
@@ -11,30 +11,35 @@ job:
         application: hello
         waitForCompletion: true
         parameters:
+          - name: INSTALL_LITMUS
+            label: install litmus
+            description: Install litmus if it is not already installed
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "false"        
           - name: APPLICATION_NAMESPACE
             label: Namespace of AUT
             description: Namespace where chaos will occur
-            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
             defaultValue: "spinnaker"
           - name: APPLICATION_LABEL
             label: Label of AUT
             description: Label by which app is filtered
-            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
             defaultValue: "name=hello"
           - name: CHAOS_DURATION
             label: Chaos duration
             description: The time duration for chaos insertion (in sec)	
-            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
             defaultValue: "30"
           - name: AMOUNT_OF_MEMORY_CONSUMPTION
             label: Memory consumption
             description: Amount of memory consumption in mb (upto 2500mb)	
-            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "500"
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of the container subjected to CPU stress
-            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
             defaultValue: "hello"
         manifest:
           apiVersion: batch/v1
@@ -50,6 +55,8 @@ job:
                   - name: run-pod-memory-hog-chaos
                     image: mayadataio/chaos-ci-lib:ci
                     env:
+                      - name: INSTALL_LITMUS
+                        value: "$(INSTALL_LITMUS)"                     
                       - name: APP_NS
                         value: $(APPLICATION_NAMESPACE)
                       - name: APP_LABEL
@@ -57,10 +64,12 @@ job:
                       - name: TOTAL_CHAOS_DURATION
                         value: "$(CHAOS_DURATION)"        
                       - name: MEMORY_CONSUMPTION
-                        value: "$(AMOUNT_OF_MEMORY_CONSUMPTION)"    
+                        value: "$(AMOUNT_OF_MEMORY_CONSUMPTION)"
                       - name: TARGET_CONTAINER
-                        value: "$(TARGET_CONTAINER)"   
+                        value: "$(TARGET_CONTAINER)"
+                      - name: EXPERIMENT_NAME
+                        value: "pod-memory-hog"                        
                     command: ["/bin/bash"]
                     args:
                     - -c 
-                    - ./pod-memory-hog
+                    - ./experiment_entrypoint.sh

--- a/templates/experiments/pod-memory-hog.yml
+++ b/templates/experiments/pod-memory-hog.yml
@@ -8,7 +8,7 @@ job:
         cloudProvider: kubernetes
         account: spinnaker
         credentials: spinnaker
-        application: hello
+        application: litmuschaos
         waitForCompletion: true
         parameters:
           - name: INSTALL_LITMUS
@@ -31,16 +31,26 @@ job:
             description: The time duration for chaos insertion (in sec)	
             mapping: manifest.spec.template.spec.containers[0].env[3].value
             defaultValue: "30"
+          - name: CHAOS_KILL_COMMAND
+            label: chaos kill command
+            description: Kills the chaos process inside the target container	
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            defaultValue: "\"kill -9 $(ps afx | grep \"[md5sum] /dev/zero\" | awk '{print$1}' | tr '\n' ' ')\""            
           - name: AMOUNT_OF_MEMORY_CONSUMPTION
             label: Memory consumption
             description: Amount of memory consumption in mb (upto 2500mb)	
-            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
             defaultValue: "500"
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of the container subjected to CPU stress
-            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            mapping: manifest.spec.template.spec.containers[0].env[6].value
             defaultValue: "hello"
+          - name: UNINSTALL_LITMUS_ON_COMPLETION
+            label: uninstall litmus
+            description: Uninstall litmus if no more test to run
+            mapping: manifest.spec.template.spec.containers[0].env[7].value
+            defaultValue: "false"             
         manifest:
           apiVersion: batch/v1
           kind: Job
@@ -62,11 +72,15 @@ job:
                       - name: APP_LABEL
                         value: $(APPLICATION_LABEL)
                       - name: TOTAL_CHAOS_DURATION
-                        value: "$(CHAOS_DURATION)"        
+                        value: "$(CHAOS_DURATION)"
+                      - name: CHAOS_KILL_COMMAND
+                        value: "$(CHAOS_KILL_COMMAND)"                         
                       - name: MEMORY_CONSUMPTION
                         value: "$(AMOUNT_OF_MEMORY_CONSUMPTION)"
                       - name: TARGET_CONTAINER
                         value: "$(TARGET_CONTAINER)"
+                      - name: UNINSTALL_LITMUS
+                        value: "$(UNINSTALL_LITMUS_ON_COMPLETION)"                           
                       - name: EXPERIMENT_NAME
                         value: "pod-memory-hog"                        
                     command: ["/bin/bash"]

--- a/templates/experiments/pod-memory-hog.yml
+++ b/templates/experiments/pod-memory-hog.yml
@@ -1,0 +1,66 @@
+---
+job:
+  preconfigured:
+    kubernetes:
+      - label: Pod-Memory-Hog-Chaos
+        type: PodMemoryHogChaosExperiment
+        description: Consume Memory resources on the application container	
+        cloudProvider: kubernetes
+        account: spinnaker
+        credentials: spinnaker
+        application: hello
+        waitForCompletion: true
+        parameters:
+          - name: APPLICATION_NAMESPACE
+            label: Namespace of AUT
+            description: Namespace where chaos will occur
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "spinnaker"
+          - name: APPLICATION_LABEL
+            label: Label of AUT
+            description: Label by which app is filtered
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            defaultValue: "name=hello"
+          - name: CHAOS_DURATION
+            label: Chaos duration
+            description: The time duration for chaos insertion (in sec)	
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            defaultValue: "30"
+          - name: AMOUNT_OF_MEMORY_CONSUMPTION
+            label: Memory consumption
+            description: Amount of memory consumption in mb (upto 2500mb)	
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            defaultValue: "500"
+          - name: TARGET_CONTAINER
+            label: Target Container
+            description: Name of the container subjected to CPU stress
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            defaultValue: "hello"
+        manifest:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+              name: run-pod-memory-hog-chaos
+          spec:
+            backoffLimit: 0
+            template:
+              spec:
+                restartPolicy: Never
+                containers: 
+                  - name: run-pod-memory-hog-chaos
+                    image: mayadataio/chaos-ci-lib:ci
+                    env:
+                      - name: APP_NS
+                        value: $(APPLICATION_NAMESPACE)
+                      - name: APP_LABEL
+                        value: $(APPLICATION_LABEL)
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "$(CHAOS_DURATION)"        
+                      - name: MEMORY_CONSUMPTION
+                        value: "$(AMOUNT_OF_MEMORY_CONSUMPTION)"    
+                      - name: TARGET_CONTAINER
+                        value: "$(TARGET_CONTAINER)"   
+                    command: ["/bin/bash"]
+                    args:
+                    - -c 
+                    - ./pod-memory-hog

--- a/templates/experiments/pod-network-corruption.yml
+++ b/templates/experiments/pod-network-corruption.yml
@@ -11,30 +11,35 @@ job:
         application: hello
         waitForCompletion: true
         parameters:
+          - name: INSTALL_LITMUS
+            label: install litmus
+            description: Install litmus if it is not already installed
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "false"          
           - name: APPLICATION_NAMESPACE
             label: Namespace of AUT
             description: Namespace where chaos will occur
-            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
             defaultValue: "spinnaker"
           - name: APPLICATION_LABEL
             label: Label of AUT
             description: Label by which app is filtered
-            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
             defaultValue: "name=hello"
           - name: CHAOS_DURATION
             label: Chaos duration
             description: The time duration for chaos insertion (in sec)	
-            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
             defaultValue: "30"            
           - name: CONTAINER_RUNTIME
             label: Container runtime
             description: The container runtime interface for the cluster
-            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "containerd"
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of container which is subjected to network corruption.
-            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
             defaultValue: "hello"
         manifest:
           apiVersion: batch/v1
@@ -50,6 +55,8 @@ job:
                   - name: run-pod-network-corruption-chaos
                     image: mayadataio/chaos-ci-lib:ci
                     env:
+                      - name: INSTALL_LITMUS
+                        value: "$(INSTALL_LITMUS)"                     
                       - name: APP_NS
                         value: $(APPLICATION_NAMESPACE)
                       - name: APP_LABEL
@@ -59,8 +66,10 @@ job:
                       - name: CONTAINER_RUNTIME
                         value: "$(CONTAINER_RUNTIME)"   
                       - name: TARGET_CONTAINER
-                        value: "$(TARGET_CONTAINER)"   
+                        value: "$(TARGET_CONTAINER)"
+                      - name: EXPERIMENT_NAME
+                        value: "pod-network-corruption"                      
                     command: ["/bin/bash"]
                     args:
                     - -c 
-                    - ./pod-network-corruption
+                    - ./experiment_entrypoint.sh

--- a/templates/experiments/pod-network-corruption.yml
+++ b/templates/experiments/pod-network-corruption.yml
@@ -8,7 +8,7 @@ job:
         cloudProvider: kubernetes
         account: spinnaker
         credentials: spinnaker
-        application: hello
+        application: litmuschaos
         waitForCompletion: true
         parameters:
           - name: INSTALL_LITMUS
@@ -36,11 +36,26 @@ job:
             description: The container runtime interface for the cluster
             mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "containerd"
+          - name: SOCKET_PATH
+            label: socket path
+            description: Provide the socket file path, applicable only for containerd runtime
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            defaultValue: "'/run/containerd/containerd.sock'"              
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of container which is subjected to network corruption.
-            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            mapping: manifest.spec.template.spec.containers[0].env[6].value
             defaultValue: "hello"
+          - name: NETWORK_INTERFACE
+            label: Network Interface
+            description: Name of ethernet interface considered for shaping traffic.
+            mapping: manifest.spec.template.spec.containers[0].env[7].value
+            defaultValue: "'eth0'"
+          - name: UNINSTALL_LITMUS_ON_COMPLETION
+            label: uninstall litmus
+            description: Uninstall litmus if no more test to run
+            mapping: manifest.spec.template.spec.containers[0].env[8].value
+            defaultValue: "false"             
         manifest:
           apiVersion: batch/v1
           kind: Job
@@ -65,8 +80,14 @@ job:
                         value: "$(CHAOS_DURATION)"   
                       - name: CONTAINER_RUNTIME
                         value: "$(CONTAINER_RUNTIME)"   
+                      - name: SOCKET_PATH
+                        value: "$(SOCKET_PATH)"
                       - name: TARGET_CONTAINER
                         value: "$(TARGET_CONTAINER)"
+                      - name: NETWORK_INTERFACE
+                        value: "$(NETWORK_INTERFACE)"                        
+                      - name: UNINSTALL_LITMUS
+                        value: "$(UNINSTALL_LITMUS_ON_COMPLETION)"                           
                       - name: EXPERIMENT_NAME
                         value: "pod-network-corruption"                      
                     command: ["/bin/bash"]

--- a/templates/experiments/pod-network-corruption.yml
+++ b/templates/experiments/pod-network-corruption.yml
@@ -1,0 +1,66 @@
+---
+job:
+  preconfigured:
+    kubernetes:
+      - label: Pod-Network-Corruption-Chaos
+        type: PodNetworkCorruptionChaosExperiment
+        description: Inject Network Packet Corruption Into Application Pod
+        cloudProvider: kubernetes
+        account: spinnaker
+        credentials: spinnaker
+        application: hello
+        waitForCompletion: true
+        parameters:
+          - name: APPLICATION_NAMESPACE
+            label: Namespace of AUT
+            description: Namespace where chaos will occur
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "spinnaker"
+          - name: APPLICATION_LABEL
+            label: Label of AUT
+            description: Label by which app is filtered
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            defaultValue: "name=hello"
+          - name: CHAOS_DURATION
+            label: Chaos duration
+            description: The time duration for chaos insertion (in sec)	
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            defaultValue: "30"            
+          - name: CONTAINER_RUNTIME
+            label: Container runtime
+            description: The container runtime interface for the cluster
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            defaultValue: "containerd"
+          - name: TARGET_CONTAINER
+            label: Target Container
+            description: Name of container which is subjected to network corruption.
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            defaultValue: "hello"
+        manifest:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+              name: run-pod-network-corruption-chaos
+          spec:
+            backoffLimit: 0
+            template:
+              spec:
+                restartPolicy: Never
+                containers: 
+                  - name: run-pod-network-corruption-chaos
+                    image: mayadataio/chaos-ci-lib:ci
+                    env:
+                      - name: APP_NS
+                        value: $(APPLICATION_NAMESPACE)
+                      - name: APP_LABEL
+                        value: $(APPLICATION_LABEL)
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "$(CHAOS_DURATION)"   
+                      - name: CONTAINER_RUNTIME
+                        value: "$(CONTAINER_RUNTIME)"   
+                      - name: TARGET_CONTAINER
+                        value: "$(TARGET_CONTAINER)"   
+                    command: ["/bin/bash"]
+                    args:
+                    - -c 
+                    - ./pod-network-corruption

--- a/templates/experiments/pod-network-duplication.yml
+++ b/templates/experiments/pod-network-duplication.yml
@@ -11,30 +11,35 @@ job:
         application: hello
         waitForCompletion: true
         parameters:
+          - name: INSTALL_LITMUS
+            label: install litmus
+            description: Install litmus if it is not already installed
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "false"        
           - name: APPLICATION_NAMESPACE
             label: Namespace of AUT
             description: Namespace where chaos will occur
-            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
             defaultValue: "spinnaker"
           - name: APPLICATION_LABEL
             label: Label of AUT
             description: Label by which app is filtered
-            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
             defaultValue: "name=hello"
           - name: CHAOS_DURATION
             label: Chaos duration
             description: The time duration for chaos insertion (in sec)	
-            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
             defaultValue: "30"            
           - name: CONTAINER_RUNTIME
             label: Container runtime
             description: The container runtime interface for the cluster
-            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "containerd"
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of container which is subjected to network duplication.
-            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
             defaultValue: "hello"
         manifest:
           apiVersion: batch/v1
@@ -50,6 +55,8 @@ job:
                   - name: run-pod-network-duplication-chaos
                     image: mayadataio/chaos-ci-lib:ci
                     env:
+                      - name: INSTALL_LITMUS
+                        value: "$(INSTALL_LITMUS)"                    
                       - name: APP_NS
                         value: $(APPLICATION_NAMESPACE)
                       - name: APP_LABEL
@@ -59,8 +66,10 @@ job:
                       - name: CONTAINER_RUNTIME
                         value: "$(CONTAINER_RUNTIME)"   
                       - name: TARGET_CONTAINER
-                        value: "$(TARGET_CONTAINER)"   
+                        value: "$(TARGET_CONTAINER)"
+                      - name: EXPERIMENT_NAME
+                        value: "pod-network-duplication"                           
                     command: ["/bin/bash"]
                     args:
                     - -c 
-                    - ./pod-network-duplication
+                    - ./experiment_entrypoint.sh

--- a/templates/experiments/pod-network-duplication.yml
+++ b/templates/experiments/pod-network-duplication.yml
@@ -8,7 +8,7 @@ job:
         cloudProvider: kubernetes
         account: spinnaker
         credentials: spinnaker
-        application: hello
+        application: litmuschaos
         waitForCompletion: true
         parameters:
           - name: INSTALL_LITMUS
@@ -36,11 +36,31 @@ job:
             description: The container runtime interface for the cluster
             mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "containerd"
+          - name: SOCKET_PATH
+            label: socket path
+            description: Provide the socket file path, applicable only for containerd runtime
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            defaultValue: "'/run/containerd/containerd.sock'"              
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of container which is subjected to network duplication.
-            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            mapping: manifest.spec.template.spec.containers[0].env[6].value
             defaultValue: "hello"
+          - name: NETWORK_INTERFACE
+            label: Network Interface
+            description: Name of ethernet interface considered for shaping traffic.
+            mapping: manifest.spec.template.spec.containers[0].env[7].value
+            defaultValue: "'eth0'"   
+          - name: NETWORK_PACKET_DUPLICATION_PERCENTAGE
+            label: Network packet duplication percentage
+            description: The packet duplication in percentage.
+            mapping: manifest.spec.template.spec.containers[0].env[8].value
+            defaultValue: "'100'"  
+          - name: UNINSTALL_LITMUS_ON_COMPLETION
+            label: uninstall litmus
+            description: Uninstall litmus if no more test to run
+            mapping: manifest.spec.template.spec.containers[0].env[9].value
+            defaultValue: "false"             
         manifest:
           apiVersion: batch/v1
           kind: Job
@@ -65,8 +85,16 @@ job:
                         value: "$(CHAOS_DURATION)"   
                       - name: CONTAINER_RUNTIME
                         value: "$(CONTAINER_RUNTIME)"   
+                      - name: SOCKET_PATH
+                        value: "$(SOCKET_PATH)"                        
                       - name: TARGET_CONTAINER
                         value: "$(TARGET_CONTAINER)"
+                      - name: NETWORK_INTERFACE
+                        value: "$(NETWORK_INTERFACE)"     
+                      - name: NETWORK_PACKET_DUPLICATION_PERCENTAGE
+                        value: "$(NETWORK_PACKET_DUPLICATION_PERCENTAGE)"                                               
+                      - name: UNINSTALL_LITMUS
+                        value: "$(UNINSTALL_LITMUS_ON_COMPLETION)"                           
                       - name: EXPERIMENT_NAME
                         value: "pod-network-duplication"                           
                     command: ["/bin/bash"]

--- a/templates/experiments/pod-network-duplication.yml
+++ b/templates/experiments/pod-network-duplication.yml
@@ -1,0 +1,66 @@
+---
+job:
+  preconfigured:
+    kubernetes:
+      - label: Pod-Network-Dn-Chaos
+        type: PodNetworkDuplicationChaosExperiment
+        description: Inject Network Packet duplication Into Application Pod
+        cloudProvider: kubernetes
+        account: spinnaker
+        credentials: spinnaker
+        application: hello
+        waitForCompletion: true
+        parameters:
+          - name: APPLICATION_NAMESPACE
+            label: Namespace of AUT
+            description: Namespace where chaos will occur
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "spinnaker"
+          - name: APPLICATION_LABEL
+            label: Label of AUT
+            description: Label by which app is filtered
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            defaultValue: "name=hello"
+          - name: CHAOS_DURATION
+            label: Chaos duration
+            description: The time duration for chaos insertion (in sec)	
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            defaultValue: "30"            
+          - name: CONTAINER_RUNTIME
+            label: Container runtime
+            description: The container runtime interface for the cluster
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            defaultValue: "containerd"
+          - name: TARGET_CONTAINER
+            label: Target Container
+            description: Name of container which is subjected to network duplication.
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            defaultValue: "hello"
+        manifest:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+              name: run-pod-network-duplication-chaos
+          spec:
+            backoffLimit: 0
+            template:
+              spec:
+                restartPolicy: Never
+                containers: 
+                  - name: run-pod-network-duplication-chaos
+                    image: mayadataio/chaos-ci-lib:ci
+                    env:
+                      - name: APP_NS
+                        value: $(APPLICATION_NAMESPACE)
+                      - name: APP_LABEL
+                        value: $(APPLICATION_LABEL)
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "$(CHAOS_DURATION)"   
+                      - name: CONTAINER_RUNTIME
+                        value: "$(CONTAINER_RUNTIME)"   
+                      - name: TARGET_CONTAINER
+                        value: "$(TARGET_CONTAINER)"   
+                    command: ["/bin/bash"]
+                    args:
+                    - -c 
+                    - ./pod-network-duplication

--- a/templates/experiments/pod-network-latency.yml
+++ b/templates/experiments/pod-network-latency.yml
@@ -11,30 +11,35 @@ job:
         application: hello
         waitForCompletion: true
         parameters:
+          - name: INSTALL_LITMUS
+            label: install litmus
+            description: Install litmus if it is not already installed
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "false"        
           - name: APPLICATION_NAMESPACE
             label: Namespace of AUT
             description: Namespace where chaos will occur
-            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
             defaultValue: "spinnaker"
           - name: APPLICATION_LABEL
             label: Label of AUT
             description: Label by which app is filtered
-            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
             defaultValue: "name=hello"
           - name: CHAOS_DURATION
             label: Chaos duration
             description: The time duration for chaos insertion (in sec)	
-            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
             defaultValue: "30"            
           - name: CONTAINER_RUNTIME
             label: Container runtime
             description: The container runtime interface for the cluster
-            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "containerd"
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of container which is subjected to network latency.
-            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
             defaultValue: "hello"
         manifest:
           apiVersion: batch/v1
@@ -50,6 +55,8 @@ job:
                   - name: run-pod-network-latency-chaos
                     image: mayadataio/chaos-ci-lib:ci
                     env:
+                      - name: INSTALL_LITMUS
+                        value: "$(INSTALL_LITMUS)"                        
                       - name: APP_NS
                         value: $(APPLICATION_NAMESPACE)
                       - name: APP_LABEL
@@ -59,8 +66,10 @@ job:
                       - name: CONTAINER_RUNTIME
                         value: "$(CONTAINER_RUNTIME)"   
                       - name: TARGET_CONTAINER
-                        value: "$(TARGET_CONTAINER)"   
+                        value: "$(TARGET_CONTAINER)"
+                      - name: EXPERIMENT_NAME
+                        value: "pod-network-latency"                          
                     command: ["/bin/bash"]
                     args:
                     - -c 
-                    - ./pod-network-latency
+                    - ./experiment_entrypoint.sh

--- a/templates/experiments/pod-network-latency.yml
+++ b/templates/experiments/pod-network-latency.yml
@@ -8,7 +8,7 @@ job:
         cloudProvider: kubernetes
         account: spinnaker
         credentials: spinnaker
-        application: hello
+        application: litmuschaos
         waitForCompletion: true
         parameters:
           - name: INSTALL_LITMUS
@@ -36,11 +36,31 @@ job:
             description: The container runtime interface for the cluster
             mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "containerd"
+          - name: SOCKET_PATH
+            label: socket path
+            description: Provide the socket file path, applicable only for containerd runtime
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            defaultValue: "'/run/containerd/containerd.sock'"              
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of container which is subjected to network latency.
-            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            mapping: manifest.spec.template.spec.containers[0].env[6].value
             defaultValue: "hello"
+          - name: NETWORK_INTERFACE
+            label: Network Interface
+            description: Name of ethernet interface considered for shaping traffic.
+            mapping: manifest.spec.template.spec.containers[0].env[7].value
+            defaultValue: "'eth0'" 
+          - name: NETWORK_LATENCY
+            label: Network Latency
+            description: The latency/delay in milliseconds.
+            mapping: manifest.spec.template.spec.containers[0].env[8].value
+            defaultValue: "'60000'"
+          - name: UNINSTALL_LITMUS_ON_COMPLETION
+            label: uninstall litmus
+            description: Uninstall litmus if no more test to run
+            mapping: manifest.spec.template.spec.containers[0].env[9].value
+            defaultValue: "false"              
         manifest:
           apiVersion: batch/v1
           kind: Job
@@ -65,8 +85,16 @@ job:
                         value: "$(CHAOS_DURATION)"   
                       - name: CONTAINER_RUNTIME
                         value: "$(CONTAINER_RUNTIME)"   
+                      - name: SOCKET_PATH
+                        value: "$(SOCKET_PATH)"                        
                       - name: TARGET_CONTAINER
                         value: "$(TARGET_CONTAINER)"
+                      - name: NETWORK_INTERFACE
+                        value: "$(NETWORK_INTERFACE)" 
+                      - name: NETWORK_LATENCY
+                        value: "$(NETWORK_LATENCY)"                                                                             
+                      - name: UNINSTALL_LITMUS
+                        value: "$(UNINSTALL_LITMUS_ON_COMPLETION)"                           
                       - name: EXPERIMENT_NAME
                         value: "pod-network-latency"                          
                     command: ["/bin/bash"]

--- a/templates/experiments/pod-network-latency.yml
+++ b/templates/experiments/pod-network-latency.yml
@@ -1,0 +1,66 @@
+---
+job:
+  preconfigured:
+    kubernetes:
+      - label: Pod-Network-Latency-Chaos
+        type: PodNetworkLatencyChaosExperiment
+        description: Inject Network Packet Latency Into Application Pod
+        cloudProvider: kubernetes
+        account: spinnaker
+        credentials: spinnaker
+        application: hello
+        waitForCompletion: true
+        parameters:
+          - name: APPLICATION_NAMESPACE
+            label: Namespace of AUT
+            description: Namespace where chaos will occur
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "spinnaker"
+          - name: APPLICATION_LABEL
+            label: Label of AUT
+            description: Label by which app is filtered
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            defaultValue: "name=hello"
+          - name: CHAOS_DURATION
+            label: Chaos duration
+            description: The time duration for chaos insertion (in sec)	
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            defaultValue: "30"            
+          - name: CONTAINER_RUNTIME
+            label: Container runtime
+            description: The container runtime interface for the cluster
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            defaultValue: "containerd"
+          - name: TARGET_CONTAINER
+            label: Target Container
+            description: Name of container which is subjected to network latency.
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            defaultValue: "hello"
+        manifest:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+              name: run-pod-network-latency-chaos
+          spec:
+            backoffLimit: 0
+            template:
+              spec:
+                restartPolicy: Never
+                containers: 
+                  - name: run-pod-network-latency-chaos
+                    image: mayadataio/chaos-ci-lib:ci
+                    env:
+                      - name: APP_NS
+                        value: $(APPLICATION_NAMESPACE)
+                      - name: APP_LABEL
+                        value: $(APPLICATION_LABEL)
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "$(CHAOS_DURATION)"   
+                      - name: CONTAINER_RUNTIME
+                        value: "$(CONTAINER_RUNTIME)"   
+                      - name: TARGET_CONTAINER
+                        value: "$(TARGET_CONTAINER)"   
+                    command: ["/bin/bash"]
+                    args:
+                    - -c 
+                    - ./pod-network-latency

--- a/templates/experiments/pod-network-loss.yml
+++ b/templates/experiments/pod-network-loss.yml
@@ -11,30 +11,35 @@ job:
         application: hello
         waitForCompletion: true
         parameters:
+          - name: INSTALL_LITMUS
+            label: install litmus
+            description: Install litmus if it is not already installed
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "false"        
           - name: APPLICATION_NAMESPACE
             label: Namespace of AUT
             description: Namespace where chaos will occur
-            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
             defaultValue: "spinnaker"
           - name: APPLICATION_LABEL
             label: Label of AUT
             description: Label by which app is filtered
-            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
             defaultValue: "name=hello"
           - name: CHAOS_DURATION
             label: Chaos duration
             description: The time duration for chaos insertion (in sec)	
-            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
             defaultValue: "30"            
           - name: CONTAINER_RUNTIME
             label: Container runtime
             description: The container runtime interface for the cluster
-            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "containerd"
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of container which is subjected to network loss.
-            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
             defaultValue: "hello"
         manifest:
           apiVersion: batch/v1
@@ -50,6 +55,8 @@ job:
                   - name: run-pod-network-loss-chaos
                     image: mayadataio/chaos-ci-lib:ci
                     env:
+                      - name: INSTALL_LITMUS
+                        value: "$(INSTALL_LITMUS)"                      
                       - name: APP_NS
                         value: $(APPLICATION_NAMESPACE)
                       - name: APP_LABEL
@@ -59,8 +66,10 @@ job:
                       - name: CONTAINER_RUNTIME
                         value: "$(CONTAINER_RUNTIME)"   
                       - name: TARGET_CONTAINER
-                        value: "$(TARGET_CONTAINER)"   
+                        value: "$(TARGET_CONTAINER)"
+                      - name: EXPERIMENT_NAME
+                        value: "pod-network-loss"                          
                     command: ["/bin/bash"]
                     args:
                     - -c 
-                    - ./pod-network-loss
+                    - ./experiment_entrypoint.sh

--- a/templates/experiments/pod-network-loss.yml
+++ b/templates/experiments/pod-network-loss.yml
@@ -1,0 +1,66 @@
+---
+job:
+  preconfigured:
+    kubernetes:
+      - label: Pod-Network-Loss-Chaos
+        type: PodNetworkLossChaosExperiment
+        description: Inject Network Packet Loss Into Application Pod
+        cloudProvider: kubernetes
+        account: spinnaker
+        credentials: spinnaker
+        application: hello
+        waitForCompletion: true
+        parameters:
+          - name: APPLICATION_NAMESPACE
+            label: Namespace of AUT
+            description: Namespace where chaos will occur
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "spinnaker"
+          - name: APPLICATION_LABEL
+            label: Label of AUT
+            description: Label by which app is filtered
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            defaultValue: "name=hello"
+          - name: CHAOS_DURATION
+            label: Chaos duration
+            description: The time duration for chaos insertion (in sec)	
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            defaultValue: "30"            
+          - name: CONTAINER_RUNTIME
+            label: Container runtime
+            description: The container runtime interface for the cluster
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            defaultValue: "containerd"
+          - name: TARGET_CONTAINER
+            label: Target Container
+            description: Name of container which is subjected to network loss.
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            defaultValue: "hello"
+        manifest:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+              name: run-pod-network-loss-chaos
+          spec:
+            backoffLimit: 0
+            template:
+              spec:
+                restartPolicy: Never
+                containers: 
+                  - name: run-pod-network-loss-chaos
+                    image: mayadataio/chaos-ci-lib:ci
+                    env:
+                      - name: APP_NS
+                        value: $(APPLICATION_NAMESPACE)
+                      - name: APP_LABEL
+                        value: $(APPLICATION_LABEL)
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "$(CHAOS_DURATION)"   
+                      - name: CONTAINER_RUNTIME
+                        value: "$(CONTAINER_RUNTIME)"   
+                      - name: TARGET_CONTAINER
+                        value: "$(TARGET_CONTAINER)"   
+                    command: ["/bin/bash"]
+                    args:
+                    - -c 
+                    - ./pod-network-loss

--- a/templates/experiments/pod-network-loss.yml
+++ b/templates/experiments/pod-network-loss.yml
@@ -8,7 +8,7 @@ job:
         cloudProvider: kubernetes
         account: spinnaker
         credentials: spinnaker
-        application: hello
+        application: litmuschaos
         waitForCompletion: true
         parameters:
           - name: INSTALL_LITMUS
@@ -36,11 +36,31 @@ job:
             description: The container runtime interface for the cluster
             mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "containerd"
+          - name: SOCKET_PATH
+            label: socket path
+            description: Provide the socket file path, applicable only for containerd runtime
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            defaultValue: "'/run/containerd/containerd.sock'"              
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of container which is subjected to network loss.
-            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            mapping: manifest.spec.template.spec.containers[0].env[6].value
             defaultValue: "hello"
+          - name: NETWORK_INTERFACE
+            label: Network Interface
+            description: Name of ethernet interface considered for shaping traffic.
+            mapping: manifest.spec.template.spec.containers[0].env[7].value
+            defaultValue: "'eth0'"
+          - name: NETWORK_PACKET_LOSS_PERCENTAGE
+            label: Network packet loss percentage
+            description: The packet loss in percentage.
+            mapping: manifest.spec.template.spec.containers[0].env[8].value
+            defaultValue: "'100'"  
+          - name: UNINSTALL_LITMUS_ON_COMPLETION
+            label: uninstall litmus
+            description: Uninstall litmus if no more test to run
+            mapping: manifest.spec.template.spec.containers[0].env[9].value
+            defaultValue: "false"              
         manifest:
           apiVersion: batch/v1
           kind: Job
@@ -65,8 +85,16 @@ job:
                         value: "$(CHAOS_DURATION)"   
                       - name: CONTAINER_RUNTIME
                         value: "$(CONTAINER_RUNTIME)"   
+                      - name: SOCKET_PATH
+                        value: "$(SOCKET_PATH)"                        
                       - name: TARGET_CONTAINER
                         value: "$(TARGET_CONTAINER)"
+                      - name: NETWORK_INTERFACE
+                        value: "$(NETWORK_INTERFACE)"  
+                      - name: NETWORK_PACKET_LOSS_PERCENTAGE
+                        value: "$(NETWORK_PACKET_LOSS_PERCENTAGE)"                                                   
+                      - name: UNINSTALL_LITMUS
+                        value: "$(UNINSTALL_LITMUS_ON_COMPLETION)"                           
                       - name: EXPERIMENT_NAME
                         value: "pod-network-loss"                          
                     command: ["/bin/bash"]

--- a/templates/litmus-infra-ops/install-litmus.yml
+++ b/templates/litmus-infra-ops/install-litmus.yml
@@ -8,7 +8,7 @@ job:
         cloudProvider: kubernetes
         account: spinnaker
         credentials: spinnaker
-        application: hello
+        application: litmuschaos
         waitForCompletion: true
         parameters:
           - name: CHAOS_OPERATOR_IMAGE

--- a/templates/litmus-infra-ops/uninstall-litmus.yml
+++ b/templates/litmus-infra-ops/uninstall-litmus.yml
@@ -8,7 +8,7 @@ job:
         cloudProvider: kubernetes
         account: spinnaker
         credentials: spinnaker
-        application: hello
+        application: litmuschaos
         waitForCompletion: true
         parameters:
           - name: APPLICATION_NAMESPACE

--- a/templates/suite/litmus-full-suite-orca-template.yml
+++ b/templates/suite/litmus-full-suite-orca-template.yml
@@ -1,54 +1,6 @@
 job:
   preconfigured:
     kubernetes:
-      - label: Install-Litmus
-        type: ChaosOperatorSetup
-        description: Install and configure litmus
-        cloudProvider: kubernetes
-        account: spinnaker
-        credentials: spinnaker
-        application: hello
-        waitForCompletion: true
-        parameters:
-          - name: CHAOS_OPERATOR_IMAGE
-            label: Image of ChaosOperator
-            description: ChaosOperator image to install litmus
-            mapping: manifest.spec.template.spec.containers[0].env[0].value
-            defaultValue: "litmuschaos/chaos-operator:latest"
-          - name: CHAOS_RUNNER_IMAGE
-            label: Image of ChaosRunner
-            description: ChaosRunner image to install litmus
-            mapping: manifest.spec.template.spec.containers[0].env[1].value
-            defaultValue: "litmuschaos/chaos-runner:latest"
-          - name: APPLICATION_NAMESPACE
-            label: Namespace of AUT
-            description: Namespace where chaos will occur
-            mapping: manifest.spec.template.spec.containers[0].env[2].value
-            defaultValue: "spinnaker"            
-        manifest:
-          apiVersion: batch/v1
-          kind: Job
-          metadata:
-            name: installation
-          spec:
-            backoffLimit: 0
-            template:
-              spec:
-                restartPolicy: Never
-                containers: 
-                  - name: installation
-                    image: mayadataio/chaos-ci-lib:ci
-                    env:
-                      - name: OPERATOR_IMAGE
-                        value: $(CHAOS_OPERATOR_IMAGE)
-                      - name: RUNNER_IMAGE
-                        value: $(CHAOS_RUNNER_IMAGE)
-                      - name: APP_NS
-                        value: $(APPLICATION_NAMESPACE)                        
-                    command: ["/bin/bash"]
-                    args:
-                    - -c 
-                    - ./install-litmus
       - label: Pod-Delete-Chaos
         type: PodDeleteChaosExperiment
         description: Kill an application pod
@@ -58,20 +10,25 @@ job:
         application: hello
         waitForCompletion: true
         parameters:
+          - name: INSTALL_LITMUS
+            label: install litmus
+            description: Install litmus if it is not already installed
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "false"           
           - name: APPLICATION_NAMESPACE
             label: Namespace of AUT
             description: Namespace where chaos will occur
-            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
             defaultValue: "spinnaker"
           - name: APPLICATION_LABEL
             label: Label of AUT
             description: Label by which app is filtered
-            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
             defaultValue: "name=hello"
           - name: CHAOS_DURATION
             label: Chaos duration
             description: The time duration for chaos insertion (in sec)	
-            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
             defaultValue: "30"                           
         manifest:
           apiVersion: batch/v1
@@ -87,16 +44,20 @@ job:
                   - name: run-pod-delete-chaos
                     image: mayadataio/chaos-ci-lib:ci
                     env:
+                      - name: INSTALL_LITMUS
+                        value: "$(INSTALL_LITMUS)"                    
                       - name: APP_NS
                         value: $(APPLICATION_NAMESPACE)
                       - name: APP_LABEL
                         value: $(APPLICATION_LABEL)
                       - name: TOTAL_CHAOS_DURATION
-                        value: "$(CHAOS_DURATION)"                          
+                        value: "$(CHAOS_DURATION)"
+                      - name: EXPERIMENT_NAME
+                        value: "pod-delete"                                                
                     command: ["/bin/bash"]
                     args:
                     - -c 
-                    - ./pod-delete
+                    - ./experiment_entrypoint.sh
       - label: Container-Kill-Chaos
         type: ContainerKillChaosExperiment
         description: Kill one container in the application pod
@@ -106,35 +67,40 @@ job:
         application: hello
         waitForCompletion: true
         parameters:
+          - name: INSTALL_LITMUS
+            label: install litmus
+            description: Install litmus if it is not already installed
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "false"        
           - name: APPLICATION_NAMESPACE
             label: Namespace of AUT
             description: Namespace where chaos will occur
-            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
             defaultValue: "spinnaker"
           - name: APPLICATION_LABEL
             label: Label of AUT
             description: Label by which app is filtered
-            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
             defaultValue: "name=hello"
           - name: CHAOS_DURATION
             label: Chaos duration
             description: The time duration for chaos insertion (in sec)	
-            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
             defaultValue: "30"
           - name: CHAOS_INTERVAL
             label: Chaos interval
             description: Time interval b/w two successive container kill (in sec)	
-            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "10"            
           - name: CONTAINER_RUNTIME
             label: Container runtime
             description: The container runtime interface for the cluster
-            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
             defaultValue: "containerd"
           - name: TARGET_CONTAINER
             label: Target Container
             description: The container to be killed inside the pod
-            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            mapping: manifest.spec.template.spec.containers[0].env[6].value
             defaultValue: "hello"
         manifest:
           apiVersion: batch/v1
@@ -150,6 +116,8 @@ job:
                   - name: run-container-kill-chaos
                     image: mayadataio/chaos-ci-lib:ci
                     env:
+                      - name: INSTALL_LITMUS
+                        value: "$(INSTALL_LITMUS)"                    
                       - name: APP_NS
                         value: $(APPLICATION_NAMESPACE)
                       - name: APP_LABEL
@@ -161,11 +129,13 @@ job:
                       - name: CONTAINER_RUNTIME
                         value: "$(CONTAINER_RUNTIME)"   
                       - name: TARGET_CONTAINER
-                        value: "$(TARGET_CONTAINER)"   
+                        value: "$(TARGET_CONTAINER)"
+                      - name: EXPERIMENT_NAME
+                        value: "container-kill"                        
                     command: ["/bin/bash"]
                     args:
                     - -c 
-                    - ./container-kill
+                    - ./experiment_entrypoint.sh
       - label: Disk-Fill-Chaos
         type: DiskFillChaosExperiment
         description: Fill up Ephemeral Storage of a Pod
@@ -175,30 +145,35 @@ job:
         application: hello
         waitForCompletion: true
         parameters:
+          - name: INSTALL_LITMUS
+            label: install litmus
+            description: Install litmus if it is not already installed
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "false"          
           - name: APPLICATION_NAMESPACE
             label: Namespace of AUT
             description: Namespace where chaos will occur
-            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
             defaultValue: "spinnaker"
           - name: APPLICATION_LABEL
             label: Label of AUT
             description: Label by which app is filtered
-            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
             defaultValue: "name=hello"
           - name: CHAOS_DURATION
             label: Chaos duration
             description: The time duration for chaos insertion (in sec)	
-            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
             defaultValue: "30"            
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of container which is subjected to disk-fill
-            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "hello"
           - name: FILL_PERCENTAGE
             label: Fill percentage
             description: Percentage to fill the Ephemeral storage limit
-            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
             defaultValue: "hello"            
         manifest:
           apiVersion: batch/v1
@@ -214,6 +189,8 @@ job:
                   - name: run-disk-fill-chaos
                     image: mayadataio/chaos-ci-lib:ci
                     env:
+                      - name: INSTALL_LITMUS
+                        value: "$(INSTALL_LITMUS)"                       
                       - name: APP_NS
                         value: $(APPLICATION_NAMESPACE)
                       - name: APP_LABEL
@@ -223,12 +200,13 @@ job:
                       - name: TARGET_CONTAINER
                         value: "$(TARGET_CONTAINER)"
                       - name: FILL_PERCENTAGE
-                        value: "$(FILL_PERCENTAGE)"                         
+                        value: "$(FILL_PERCENTAGE)"
+                      - name: EXPERIMENT_NAME
+                        value: "disk-fill"                                                   
                     command: ["/bin/bash"]
                     args:
                     - -c 
-                    - ./disk-fill
-
+                    - ./experiment_entrypoint.sh
       - label: Pod-CPU-Hog-Chaos
         type: PodCPUHogChaosExperiment
         description: Consume CPU resources on the application container	
@@ -238,30 +216,35 @@ job:
         application: hello
         waitForCompletion: true
         parameters:
+          - name: INSTALL_LITMUS
+            label: install litmus
+            description: Install litmus if it is not already installed
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "false"          
           - name: APPLICATION_NAMESPACE
             label: Namespace of AUT
             description: Namespace where chaos will occur
-            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
             defaultValue: "spinnaker"
           - name: APPLICATION_LABEL
             label: Label of AUT
             description: Label by which app is filtered
-            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
             defaultValue: "name=hello"
           - name: CHAOS_DURATION
             label: Chaos duration
             description: The time duration for chaos insertion (in sec)	
-            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
             defaultValue: "30"
           - name: NUMBER_OF_CPU_CORES
             label: Cores of CPU
             description: Number of the cpu cores subjected to CPU stress	
-            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "1"
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of the container subjected to CPU stress
-            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
             defaultValue: "hello"
         manifest:
           apiVersion: batch/v1
@@ -277,6 +260,8 @@ job:
                   - name: run-pod-cpu-hog-chaos
                     image: mayadataio/chaos-ci-lib:ci
                     env:
+                      - name: INSTALL_LITMUS
+                        value: "$(INSTALL_LITMUS)"                    
                       - name: APP_NS
                         value: $(APPLICATION_NAMESPACE)
                       - name: APP_LABEL
@@ -286,11 +271,13 @@ job:
                       - name: CPU_CORES
                         value: "$(NUMBER_OF_CPU_CORES)"    
                       - name: TARGET_CONTAINER
-                        value: "$(TARGET_CONTAINER)"   
+                        value: "$(TARGET_CONTAINER)"
+                      - name: EXPERIMENT_NAME
+                        value: "pod-cpu-hog"                          
                     command: ["/bin/bash"]
                     args:
                     - -c 
-                    - ./pod-cpu-hog
+                    - ./experiment_entrypoint.sh
       - label: Pod-Memory-Hog-Chaos
         type: PodMemoryHogChaosExperiment
         description: Consume Memory resources on the application container	
@@ -300,30 +287,35 @@ job:
         application: hello
         waitForCompletion: true
         parameters:
+          - name: INSTALL_LITMUS
+            label: install litmus
+            description: Install litmus if it is not already installed
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "false"        
           - name: APPLICATION_NAMESPACE
             label: Namespace of AUT
             description: Namespace where chaos will occur
-            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
             defaultValue: "spinnaker"
           - name: APPLICATION_LABEL
             label: Label of AUT
             description: Label by which app is filtered
-            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
             defaultValue: "name=hello"
           - name: CHAOS_DURATION
             label: Chaos duration
             description: The time duration for chaos insertion (in sec)	
-            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
             defaultValue: "30"
           - name: AMOUNT_OF_MEMORY_CONSUMPTION
             label: Memory consumption
             description: Amount of memory consumption in mb (upto 2500mb)	
-            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "500"
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of the container subjected to CPU stress
-            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
             defaultValue: "hello"
         manifest:
           apiVersion: batch/v1
@@ -339,6 +331,8 @@ job:
                   - name: run-pod-memory-hog-chaos
                     image: mayadataio/chaos-ci-lib:ci
                     env:
+                      - name: INSTALL_LITMUS
+                        value: "$(INSTALL_LITMUS)"                     
                       - name: APP_NS
                         value: $(APPLICATION_NAMESPACE)
                       - name: APP_LABEL
@@ -346,13 +340,15 @@ job:
                       - name: TOTAL_CHAOS_DURATION
                         value: "$(CHAOS_DURATION)"        
                       - name: MEMORY_CONSUMPTION
-                        value: "$(AMOUNT_OF_MEMORY_CONSUMPTION)"    
+                        value: "$(AMOUNT_OF_MEMORY_CONSUMPTION)"
                       - name: TARGET_CONTAINER
-                        value: "$(TARGET_CONTAINER)"   
+                        value: "$(TARGET_CONTAINER)"
+                      - name: EXPERIMENT_NAME
+                        value: "pod-memory-hog"                        
                     command: ["/bin/bash"]
                     args:
                     - -c 
-                    - ./pod-memory-hog
+                    - ./experiment_entrypoint.sh
       - label: Pod-Network-Corruption-Chaos
         type: PodNetworkCorruptionChaosExperiment
         description: Inject Network Packet Corruption Into Application Pod
@@ -362,30 +358,35 @@ job:
         application: hello
         waitForCompletion: true
         parameters:
+          - name: INSTALL_LITMUS
+            label: install litmus
+            description: Install litmus if it is not already installed
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "false"          
           - name: APPLICATION_NAMESPACE
             label: Namespace of AUT
             description: Namespace where chaos will occur
-            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
             defaultValue: "spinnaker"
           - name: APPLICATION_LABEL
             label: Label of AUT
             description: Label by which app is filtered
-            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
             defaultValue: "name=hello"
           - name: CHAOS_DURATION
             label: Chaos duration
             description: The time duration for chaos insertion (in sec)	
-            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
             defaultValue: "30"            
           - name: CONTAINER_RUNTIME
             label: Container runtime
             description: The container runtime interface for the cluster
-            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "containerd"
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of container which is subjected to network corruption.
-            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
             defaultValue: "hello"
         manifest:
           apiVersion: batch/v1
@@ -401,6 +402,8 @@ job:
                   - name: run-pod-network-corruption-chaos
                     image: mayadataio/chaos-ci-lib:ci
                     env:
+                      - name: INSTALL_LITMUS
+                        value: "$(INSTALL_LITMUS)"                     
                       - name: APP_NS
                         value: $(APPLICATION_NAMESPACE)
                       - name: APP_LABEL
@@ -410,11 +413,13 @@ job:
                       - name: CONTAINER_RUNTIME
                         value: "$(CONTAINER_RUNTIME)"   
                       - name: TARGET_CONTAINER
-                        value: "$(TARGET_CONTAINER)"   
+                        value: "$(TARGET_CONTAINER)"
+                      - name: EXPERIMENT_NAME
+                        value: "pod-network-corruption"                      
                     command: ["/bin/bash"]
                     args:
                     - -c 
-                    - ./pod-network-corruption
+                    - ./experiment_entrypoint.sh
       - label: Pod-Network-Dn-Chaos
         type: PodNetworkDuplicationChaosExperiment
         description: Inject Network Packet duplication Into Application Pod
@@ -424,30 +429,35 @@ job:
         application: hello
         waitForCompletion: true
         parameters:
+          - name: INSTALL_LITMUS
+            label: install litmus
+            description: Install litmus if it is not already installed
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "false"        
           - name: APPLICATION_NAMESPACE
             label: Namespace of AUT
             description: Namespace where chaos will occur
-            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
             defaultValue: "spinnaker"
           - name: APPLICATION_LABEL
             label: Label of AUT
             description: Label by which app is filtered
-            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
             defaultValue: "name=hello"
           - name: CHAOS_DURATION
             label: Chaos duration
             description: The time duration for chaos insertion (in sec)	
-            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
             defaultValue: "30"            
           - name: CONTAINER_RUNTIME
             label: Container runtime
             description: The container runtime interface for the cluster
-            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "containerd"
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of container which is subjected to network duplication.
-            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
             defaultValue: "hello"
         manifest:
           apiVersion: batch/v1
@@ -463,6 +473,8 @@ job:
                   - name: run-pod-network-duplication-chaos
                     image: mayadataio/chaos-ci-lib:ci
                     env:
+                      - name: INSTALL_LITMUS
+                        value: "$(INSTALL_LITMUS)"                    
                       - name: APP_NS
                         value: $(APPLICATION_NAMESPACE)
                       - name: APP_LABEL
@@ -472,11 +484,13 @@ job:
                       - name: CONTAINER_RUNTIME
                         value: "$(CONTAINER_RUNTIME)"   
                       - name: TARGET_CONTAINER
-                        value: "$(TARGET_CONTAINER)"   
+                        value: "$(TARGET_CONTAINER)"
+                      - name: EXPERIMENT_NAME
+                        value: "pod-network-duplication"                           
                     command: ["/bin/bash"]
                     args:
                     - -c 
-                    - ./pod-network-duplication
+                    - ./experiment_entrypoint.sh
       - label: Pod-Network-Latency-Chaos
         type: PodNetworkLatencyChaosExperiment
         description: Inject Network Packet Latency Into Application Pod
@@ -486,30 +500,35 @@ job:
         application: hello
         waitForCompletion: true
         parameters:
+          - name: INSTALL_LITMUS
+            label: install litmus
+            description: Install litmus if it is not already installed
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "false"        
           - name: APPLICATION_NAMESPACE
             label: Namespace of AUT
             description: Namespace where chaos will occur
-            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
             defaultValue: "spinnaker"
           - name: APPLICATION_LABEL
             label: Label of AUT
             description: Label by which app is filtered
-            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
             defaultValue: "name=hello"
           - name: CHAOS_DURATION
             label: Chaos duration
             description: The time duration for chaos insertion (in sec)	
-            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
             defaultValue: "30"            
           - name: CONTAINER_RUNTIME
             label: Container runtime
             description: The container runtime interface for the cluster
-            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "containerd"
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of container which is subjected to network latency.
-            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
             defaultValue: "hello"
         manifest:
           apiVersion: batch/v1
@@ -525,6 +544,8 @@ job:
                   - name: run-pod-network-latency-chaos
                     image: mayadataio/chaos-ci-lib:ci
                     env:
+                      - name: INSTALL_LITMUS
+                        value: "$(INSTALL_LITMUS)"                        
                       - name: APP_NS
                         value: $(APPLICATION_NAMESPACE)
                       - name: APP_LABEL
@@ -534,11 +555,13 @@ job:
                       - name: CONTAINER_RUNTIME
                         value: "$(CONTAINER_RUNTIME)"   
                       - name: TARGET_CONTAINER
-                        value: "$(TARGET_CONTAINER)"   
+                        value: "$(TARGET_CONTAINER)"
+                      - name: EXPERIMENT_NAME
+                        value: "pod-network-latency"                          
                     command: ["/bin/bash"]
                     args:
                     - -c 
-                    - ./pod-network-latency
+                    - ./experiment_entrypoint.sh
       - label: Pod-Network-Loss-Chaos
         type: PodNetworkLossChaosExperiment
         description: Inject Network Packet Loss Into Application Pod
@@ -548,30 +571,35 @@ job:
         application: hello
         waitForCompletion: true
         parameters:
+          - name: INSTALL_LITMUS
+            label: install litmus
+            description: Install litmus if it is not already installed
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "false"        
           - name: APPLICATION_NAMESPACE
             label: Namespace of AUT
             description: Namespace where chaos will occur
-            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
             defaultValue: "spinnaker"
           - name: APPLICATION_LABEL
             label: Label of AUT
             description: Label by which app is filtered
-            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
             defaultValue: "name=hello"
           - name: CHAOS_DURATION
             label: Chaos duration
             description: The time duration for chaos insertion (in sec)	
-            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
             defaultValue: "30"            
           - name: CONTAINER_RUNTIME
             label: Container runtime
             description: The container runtime interface for the cluster
-            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "containerd"
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of container which is subjected to network loss.
-            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
             defaultValue: "hello"
         manifest:
           apiVersion: batch/v1
@@ -587,6 +615,8 @@ job:
                   - name: run-pod-network-loss-chaos
                     image: mayadataio/chaos-ci-lib:ci
                     env:
+                      - name: INSTALL_LITMUS
+                        value: "$(INSTALL_LITMUS)"                      
                       - name: APP_NS
                         value: $(APPLICATION_NAMESPACE)
                       - name: APP_LABEL
@@ -596,11 +626,13 @@ job:
                       - name: CONTAINER_RUNTIME
                         value: "$(CONTAINER_RUNTIME)"   
                       - name: TARGET_CONTAINER
-                        value: "$(TARGET_CONTAINER)"   
+                        value: "$(TARGET_CONTAINER)"
+                      - name: EXPERIMENT_NAME
+                        value: "pod-network-loss"                          
                     command: ["/bin/bash"]
                     args:
                     - -c 
-                    - ./pod-network-loss
+                    - ./experiment_entrypoint.sh
       - label: Uninstall-Litmus
         type: ChaosOperatorRemove
         description: Uninstall litmus and its components
@@ -635,4 +667,3 @@ job:
                     args:
                     - -c 
                     - ./uninstall-litmus
-

--- a/templates/suite/litmus-full-suite-orca-template.yml
+++ b/templates/suite/litmus-full-suite-orca-template.yml
@@ -50,7 +50,7 @@ job:
                     - -c 
                     - ./install-litmus
       - label: Pod-Delete-Chaos
-        type: ChaosExperiment
+        type: PodDeleteChaosExperiment
         description: Kill an application pod
         cloudProvider: kubernetes
         account: spinnaker
@@ -97,6 +97,510 @@ job:
                     args:
                     - -c 
                     - ./pod-delete
+      - label: Container-Kill-Chaos
+        type: ContainerKillChaosExperiment
+        description: Kill one container in the application pod
+        cloudProvider: kubernetes
+        account: spinnaker
+        credentials: spinnaker
+        application: hello
+        waitForCompletion: true
+        parameters:
+          - name: APPLICATION_NAMESPACE
+            label: Namespace of AUT
+            description: Namespace where chaos will occur
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "spinnaker"
+          - name: APPLICATION_LABEL
+            label: Label of AUT
+            description: Label by which app is filtered
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            defaultValue: "name=hello"
+          - name: CHAOS_DURATION
+            label: Chaos duration
+            description: The time duration for chaos insertion (in sec)	
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            defaultValue: "30"
+          - name: CHAOS_INTERVAL
+            label: Chaos interval
+            description: Time interval b/w two successive container kill (in sec)	
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            defaultValue: "10"            
+          - name: CONTAINER_RUNTIME
+            label: Container runtime
+            description: The container runtime interface for the cluster
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            defaultValue: "containerd"
+          - name: TARGET_CONTAINER
+            label: Target Container
+            description: The container to be killed inside the pod
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            defaultValue: "hello"
+        manifest:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+              name: run-container-kill-chaos
+          spec:
+            backoffLimit: 0
+            template:
+              spec:
+                restartPolicy: Never
+                containers: 
+                  - name: run-container-kill-chaos
+                    image: mayadataio/chaos-ci-lib:ci
+                    env:
+                      - name: APP_NS
+                        value: $(APPLICATION_NAMESPACE)
+                      - name: APP_LABEL
+                        value: $(APPLICATION_LABEL)
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "$(CHAOS_DURATION)"        
+                      - name: CHAOS_INTERVAL
+                        value: "$(CHAOS_INTERVAL)"    
+                      - name: CONTAINER_RUNTIME
+                        value: "$(CONTAINER_RUNTIME)"   
+                      - name: TARGET_CONTAINER
+                        value: "$(TARGET_CONTAINER)"   
+                    command: ["/bin/bash"]
+                    args:
+                    - -c 
+                    - ./container-kill
+      - label: Disk-Fill-Chaos
+        type: DiskFillChaosExperiment
+        description: Fill up Ephemeral Storage of a Pod
+        cloudProvider: kubernetes
+        account: spinnaker
+        credentials: spinnaker
+        application: hello
+        waitForCompletion: true
+        parameters:
+          - name: APPLICATION_NAMESPACE
+            label: Namespace of AUT
+            description: Namespace where chaos will occur
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "spinnaker"
+          - name: APPLICATION_LABEL
+            label: Label of AUT
+            description: Label by which app is filtered
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            defaultValue: "name=hello"
+          - name: CHAOS_DURATION
+            label: Chaos duration
+            description: The time duration for chaos insertion (in sec)	
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            defaultValue: "30"            
+          - name: TARGET_CONTAINER
+            label: Target Container
+            description: Name of container which is subjected to disk-fill
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            defaultValue: "hello"
+          - name: FILL_PERCENTAGE
+            label: Fill percentage
+            description: Percentage to fill the Ephemeral storage limit
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            defaultValue: "hello"            
+        manifest:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+              name: run-disk-fill-chaos
+          spec:
+            backoffLimit: 0
+            template:
+              spec:
+                restartPolicy: Never
+                containers: 
+                  - name: run-disk-fill-chaos
+                    image: mayadataio/chaos-ci-lib:ci
+                    env:
+                      - name: APP_NS
+                        value: $(APPLICATION_NAMESPACE)
+                      - name: APP_LABEL
+                        value: $(APPLICATION_LABEL)
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "$(CHAOS_DURATION)"
+                      - name: TARGET_CONTAINER
+                        value: "$(TARGET_CONTAINER)"
+                      - name: FILL_PERCENTAGE
+                        value: "$(FILL_PERCENTAGE)"                         
+                    command: ["/bin/bash"]
+                    args:
+                    - -c 
+                    - ./disk-fill
+
+      - label: Pod-CPU-Hog-Chaos
+        type: PodCPUHogChaosExperiment
+        description: Consume CPU resources on the application container	
+        cloudProvider: kubernetes
+        account: spinnaker
+        credentials: spinnaker
+        application: hello
+        waitForCompletion: true
+        parameters:
+          - name: APPLICATION_NAMESPACE
+            label: Namespace of AUT
+            description: Namespace where chaos will occur
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "spinnaker"
+          - name: APPLICATION_LABEL
+            label: Label of AUT
+            description: Label by which app is filtered
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            defaultValue: "name=hello"
+          - name: CHAOS_DURATION
+            label: Chaos duration
+            description: The time duration for chaos insertion (in sec)	
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            defaultValue: "30"
+          - name: NUMBER_OF_CPU_CORES
+            label: Cores of CPU
+            description: Number of the cpu cores subjected to CPU stress	
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            defaultValue: "1"
+          - name: TARGET_CONTAINER
+            label: Target Container
+            description: Name of the container subjected to CPU stress
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            defaultValue: "hello"
+        manifest:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+              name: run-pod-cpu-hog-chaos
+          spec:
+            backoffLimit: 0
+            template:
+              spec:
+                restartPolicy: Never
+                containers: 
+                  - name: run-pod-cpu-hog-chaos
+                    image: mayadataio/chaos-ci-lib:ci
+                    env:
+                      - name: APP_NS
+                        value: $(APPLICATION_NAMESPACE)
+                      - name: APP_LABEL
+                        value: $(APPLICATION_LABEL)
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "$(CHAOS_DURATION)"        
+                      - name: CPU_CORES
+                        value: "$(NUMBER_OF_CPU_CORES)"    
+                      - name: TARGET_CONTAINER
+                        value: "$(TARGET_CONTAINER)"   
+                    command: ["/bin/bash"]
+                    args:
+                    - -c 
+                    - ./pod-cpu-hog
+      - label: Pod-Memory-Hog-Chaos
+        type: PodMemoryHogChaosExperiment
+        description: Consume Memory resources on the application container	
+        cloudProvider: kubernetes
+        account: spinnaker
+        credentials: spinnaker
+        application: hello
+        waitForCompletion: true
+        parameters:
+          - name: APPLICATION_NAMESPACE
+            label: Namespace of AUT
+            description: Namespace where chaos will occur
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "spinnaker"
+          - name: APPLICATION_LABEL
+            label: Label of AUT
+            description: Label by which app is filtered
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            defaultValue: "name=hello"
+          - name: CHAOS_DURATION
+            label: Chaos duration
+            description: The time duration for chaos insertion (in sec)	
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            defaultValue: "30"
+          - name: AMOUNT_OF_MEMORY_CONSUMPTION
+            label: Memory consumption
+            description: Amount of memory consumption in mb (upto 2500mb)	
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            defaultValue: "500"
+          - name: TARGET_CONTAINER
+            label: Target Container
+            description: Name of the container subjected to CPU stress
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            defaultValue: "hello"
+        manifest:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+              name: run-pod-memory-hog-chaos
+          spec:
+            backoffLimit: 0
+            template:
+              spec:
+                restartPolicy: Never
+                containers: 
+                  - name: run-pod-memory-hog-chaos
+                    image: mayadataio/chaos-ci-lib:ci
+                    env:
+                      - name: APP_NS
+                        value: $(APPLICATION_NAMESPACE)
+                      - name: APP_LABEL
+                        value: $(APPLICATION_LABEL)
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "$(CHAOS_DURATION)"        
+                      - name: MEMORY_CONSUMPTION
+                        value: "$(AMOUNT_OF_MEMORY_CONSUMPTION)"    
+                      - name: TARGET_CONTAINER
+                        value: "$(TARGET_CONTAINER)"   
+                    command: ["/bin/bash"]
+                    args:
+                    - -c 
+                    - ./pod-memory-hog
+      - label: Pod-Network-Corruption-Chaos
+        type: PodNetworkCorruptionChaosExperiment
+        description: Inject Network Packet Corruption Into Application Pod
+        cloudProvider: kubernetes
+        account: spinnaker
+        credentials: spinnaker
+        application: hello
+        waitForCompletion: true
+        parameters:
+          - name: APPLICATION_NAMESPACE
+            label: Namespace of AUT
+            description: Namespace where chaos will occur
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "spinnaker"
+          - name: APPLICATION_LABEL
+            label: Label of AUT
+            description: Label by which app is filtered
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            defaultValue: "name=hello"
+          - name: CHAOS_DURATION
+            label: Chaos duration
+            description: The time duration for chaos insertion (in sec)	
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            defaultValue: "30"            
+          - name: CONTAINER_RUNTIME
+            label: Container runtime
+            description: The container runtime interface for the cluster
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            defaultValue: "containerd"
+          - name: TARGET_CONTAINER
+            label: Target Container
+            description: Name of container which is subjected to network corruption.
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            defaultValue: "hello"
+        manifest:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+              name: run-pod-network-corruption-chaos
+          spec:
+            backoffLimit: 0
+            template:
+              spec:
+                restartPolicy: Never
+                containers: 
+                  - name: run-pod-network-corruption-chaos
+                    image: mayadataio/chaos-ci-lib:ci
+                    env:
+                      - name: APP_NS
+                        value: $(APPLICATION_NAMESPACE)
+                      - name: APP_LABEL
+                        value: $(APPLICATION_LABEL)
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "$(CHAOS_DURATION)"   
+                      - name: CONTAINER_RUNTIME
+                        value: "$(CONTAINER_RUNTIME)"   
+                      - name: TARGET_CONTAINER
+                        value: "$(TARGET_CONTAINER)"   
+                    command: ["/bin/bash"]
+                    args:
+                    - -c 
+                    - ./pod-network-corruption
+      - label: Pod-Network-Dn-Chaos
+        type: PodNetworkDuplicationChaosExperiment
+        description: Inject Network Packet duplication Into Application Pod
+        cloudProvider: kubernetes
+        account: spinnaker
+        credentials: spinnaker
+        application: hello
+        waitForCompletion: true
+        parameters:
+          - name: APPLICATION_NAMESPACE
+            label: Namespace of AUT
+            description: Namespace where chaos will occur
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "spinnaker"
+          - name: APPLICATION_LABEL
+            label: Label of AUT
+            description: Label by which app is filtered
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            defaultValue: "name=hello"
+          - name: CHAOS_DURATION
+            label: Chaos duration
+            description: The time duration for chaos insertion (in sec)	
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            defaultValue: "30"            
+          - name: CONTAINER_RUNTIME
+            label: Container runtime
+            description: The container runtime interface for the cluster
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            defaultValue: "containerd"
+          - name: TARGET_CONTAINER
+            label: Target Container
+            description: Name of container which is subjected to network duplication.
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            defaultValue: "hello"
+        manifest:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+              name: run-pod-network-duplication-chaos
+          spec:
+            backoffLimit: 0
+            template:
+              spec:
+                restartPolicy: Never
+                containers: 
+                  - name: run-pod-network-duplication-chaos
+                    image: mayadataio/chaos-ci-lib:ci
+                    env:
+                      - name: APP_NS
+                        value: $(APPLICATION_NAMESPACE)
+                      - name: APP_LABEL
+                        value: $(APPLICATION_LABEL)
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "$(CHAOS_DURATION)"   
+                      - name: CONTAINER_RUNTIME
+                        value: "$(CONTAINER_RUNTIME)"   
+                      - name: TARGET_CONTAINER
+                        value: "$(TARGET_CONTAINER)"   
+                    command: ["/bin/bash"]
+                    args:
+                    - -c 
+                    - ./pod-network-duplication
+      - label: Pod-Network-Latency-Chaos
+        type: PodNetworkLatencyChaosExperiment
+        description: Inject Network Packet Latency Into Application Pod
+        cloudProvider: kubernetes
+        account: spinnaker
+        credentials: spinnaker
+        application: hello
+        waitForCompletion: true
+        parameters:
+          - name: APPLICATION_NAMESPACE
+            label: Namespace of AUT
+            description: Namespace where chaos will occur
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "spinnaker"
+          - name: APPLICATION_LABEL
+            label: Label of AUT
+            description: Label by which app is filtered
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            defaultValue: "name=hello"
+          - name: CHAOS_DURATION
+            label: Chaos duration
+            description: The time duration for chaos insertion (in sec)	
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            defaultValue: "30"            
+          - name: CONTAINER_RUNTIME
+            label: Container runtime
+            description: The container runtime interface for the cluster
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            defaultValue: "containerd"
+          - name: TARGET_CONTAINER
+            label: Target Container
+            description: Name of container which is subjected to network latency.
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            defaultValue: "hello"
+        manifest:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+              name: run-pod-network-latency-chaos
+          spec:
+            backoffLimit: 0
+            template:
+              spec:
+                restartPolicy: Never
+                containers: 
+                  - name: run-pod-network-latency-chaos
+                    image: mayadataio/chaos-ci-lib:ci
+                    env:
+                      - name: APP_NS
+                        value: $(APPLICATION_NAMESPACE)
+                      - name: APP_LABEL
+                        value: $(APPLICATION_LABEL)
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "$(CHAOS_DURATION)"   
+                      - name: CONTAINER_RUNTIME
+                        value: "$(CONTAINER_RUNTIME)"   
+                      - name: TARGET_CONTAINER
+                        value: "$(TARGET_CONTAINER)"   
+                    command: ["/bin/bash"]
+                    args:
+                    - -c 
+                    - ./pod-network-latency
+      - label: Pod-Network-Loss-Chaos
+        type: PodNetworkLossChaosExperiment
+        description: Inject Network Packet Loss Into Application Pod
+        cloudProvider: kubernetes
+        account: spinnaker
+        credentials: spinnaker
+        application: hello
+        waitForCompletion: true
+        parameters:
+          - name: APPLICATION_NAMESPACE
+            label: Namespace of AUT
+            description: Namespace where chaos will occur
+            mapping: manifest.spec.template.spec.containers[0].env[0].value
+            defaultValue: "spinnaker"
+          - name: APPLICATION_LABEL
+            label: Label of AUT
+            description: Label by which app is filtered
+            mapping: manifest.spec.template.spec.containers[0].env[1].value
+            defaultValue: "name=hello"
+          - name: CHAOS_DURATION
+            label: Chaos duration
+            description: The time duration for chaos insertion (in sec)	
+            mapping: manifest.spec.template.spec.containers[0].env[2].value
+            defaultValue: "30"            
+          - name: CONTAINER_RUNTIME
+            label: Container runtime
+            description: The container runtime interface for the cluster
+            mapping: manifest.spec.template.spec.containers[0].env[3].value
+            defaultValue: "containerd"
+          - name: TARGET_CONTAINER
+            label: Target Container
+            description: Name of container which is subjected to network loss.
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            defaultValue: "hello"
+        manifest:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+              name: run-pod-network-loss-chaos
+          spec:
+            backoffLimit: 0
+            template:
+              spec:
+                restartPolicy: Never
+                containers: 
+                  - name: run-pod-network-loss-chaos
+                    image: mayadataio/chaos-ci-lib:ci
+                    env:
+                      - name: APP_NS
+                        value: $(APPLICATION_NAMESPACE)
+                      - name: APP_LABEL
+                        value: $(APPLICATION_LABEL)
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "$(CHAOS_DURATION)"   
+                      - name: CONTAINER_RUNTIME
+                        value: "$(CONTAINER_RUNTIME)"   
+                      - name: TARGET_CONTAINER
+                        value: "$(TARGET_CONTAINER)"   
+                    command: ["/bin/bash"]
+                    args:
+                    - -c 
+                    - ./pod-network-loss
       - label: Uninstall-Litmus
         type: ChaosOperatorRemove
         description: Uninstall litmus and its components

--- a/templates/suite/litmus-full-suite-orca-template.yml
+++ b/templates/suite/litmus-full-suite-orca-template.yml
@@ -7,7 +7,7 @@ job:
         cloudProvider: kubernetes
         account: spinnaker
         credentials: spinnaker
-        application: hello
+        application: litmuschaos
         waitForCompletion: true
         parameters:
           - name: INSTALL_LITMUS
@@ -29,7 +29,22 @@ job:
             label: Chaos duration
             description: The time duration for chaos insertion (in sec)	
             mapping: manifest.spec.template.spec.containers[0].env[3].value
-            defaultValue: "30"                           
+            defaultValue: "30" 
+          - name: CHAOS_INTERVAL
+            label: Chaos interval
+            description: Time interval b/w two successive pod deletes (in sec)	
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            defaultValue: "10"   
+          - name: FORCE_DELETE
+            label: force
+            description: To delete pod forcefully	
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            defaultValue: "false"   
+          - name: UNINSTALL_LITMUS_ON_COMPLETION
+            label: uninstall litmus
+            description: Uninstall litmus if no more test to run
+            mapping: manifest.spec.template.spec.containers[0].env[6].value
+            defaultValue: "false"                                       
         manifest:
           apiVersion: batch/v1
           kind: Job
@@ -52,6 +67,12 @@ job:
                         value: $(APPLICATION_LABEL)
                       - name: TOTAL_CHAOS_DURATION
                         value: "$(CHAOS_DURATION)"
+                      - name: CHAOS_INTERVAL
+                        value: "$(CHAOS_INTERVAL)"
+                      - name: FORCE
+                        value: "$(FORCE_DELETE)"
+                      - name: UNINSTALL_LITMUS
+                        value: "$(UNINSTALL_LITMUS_ON_COMPLETION)"                           
                       - name: EXPERIMENT_NAME
                         value: "pod-delete"                                                
                     command: ["/bin/bash"]
@@ -64,7 +85,7 @@ job:
         cloudProvider: kubernetes
         account: spinnaker
         credentials: spinnaker
-        application: hello
+        application: litmuschaos
         waitForCompletion: true
         parameters:
           - name: INSTALL_LITMUS
@@ -97,11 +118,21 @@ job:
             description: The container runtime interface for the cluster
             mapping: manifest.spec.template.spec.containers[0].env[5].value
             defaultValue: "containerd"
+          - name: SOCKET_PATH
+            label: socket path
+            description: Provide the socket file path, applicable only for containerd runtime
+            mapping: manifest.spec.template.spec.containers[0].env[6].value
+            defaultValue: "'/run/containerd/containerd.sock'"            
           - name: TARGET_CONTAINER
             label: Target Container
             description: The container to be killed inside the pod
-            mapping: manifest.spec.template.spec.containers[0].env[6].value
+            mapping: manifest.spec.template.spec.containers[0].env[7].value
             defaultValue: "hello"
+          - name: UNINSTALL_LITMUS_ON_COMPLETION
+            label: uninstall litmus
+            description: Uninstall litmus if no more test to run
+            mapping: manifest.spec.template.spec.containers[0].env[8].value
+            defaultValue: "false"      
         manifest:
           apiVersion: batch/v1
           kind: Job
@@ -130,6 +161,10 @@ job:
                         value: "$(CONTAINER_RUNTIME)"   
                       - name: TARGET_CONTAINER
                         value: "$(TARGET_CONTAINER)"
+                      - name: SOCKET_PATH
+                        value: "$(SOCKET_PATH)"                        
+                      - name: UNINSTALL_LITMUS
+                        value: "$(UNINSTALL_LITMUS_ON_COMPLETION)"                          
                       - name: EXPERIMENT_NAME
                         value: "container-kill"                        
                     command: ["/bin/bash"]
@@ -142,7 +177,7 @@ job:
         cloudProvider: kubernetes
         account: spinnaker
         credentials: spinnaker
-        application: hello
+        application: litmuschaos
         waitForCompletion: true
         parameters:
           - name: INSTALL_LITMUS
@@ -174,7 +209,12 @@ job:
             label: Fill percentage
             description: Percentage to fill the Ephemeral storage limit
             mapping: manifest.spec.template.spec.containers[0].env[5].value
-            defaultValue: "hello"            
+            defaultValue: "hello"
+          - name: UNINSTALL_LITMUS_ON_COMPLETION
+            label: uninstall litmus
+            description: Uninstall litmus if no more test to run
+            mapping: manifest.spec.template.spec.containers[0].env[6].value
+            defaultValue: "false"                     
         manifest:
           apiVersion: batch/v1
           kind: Job
@@ -201,6 +241,8 @@ job:
                         value: "$(TARGET_CONTAINER)"
                       - name: FILL_PERCENTAGE
                         value: "$(FILL_PERCENTAGE)"
+                      - name: UNINSTALL_LITMUS
+                        value: "$(UNINSTALL_LITMUS_ON_COMPLETION)"                           
                       - name: EXPERIMENT_NAME
                         value: "disk-fill"                                                   
                     command: ["/bin/bash"]
@@ -213,7 +255,7 @@ job:
         cloudProvider: kubernetes
         account: spinnaker
         credentials: spinnaker
-        application: hello
+        application: litmuschaos
         waitForCompletion: true
         parameters:
           - name: INSTALL_LITMUS
@@ -241,11 +283,26 @@ job:
             description: Number of the cpu cores subjected to CPU stress	
             mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "1"
+          - name: CHAOS_INJECT_COMMAND
+            label: chaos inject command
+            description: Command to inject cpu chaos 	
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            defaultValue: "'md5sum /dev/zero'"    
+          - name: CHAOS_KILL_COMMAND
+            label: chaos kill command
+            description: Kills the chaos process inside the target container	
+            mapping: manifest.spec.template.spec.containers[0].env[6].value
+            defaultValue: "\"kill -9 $(ps afx | grep \"[md5sum] /dev/zero\" | awk '{print$1}' | tr '\n' ' ')\""
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of the container subjected to CPU stress
-            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            mapping: manifest.spec.template.spec.containers[0].env[7].value
             defaultValue: "hello"
+          - name: UNINSTALL_LITMUS_ON_COMPLETION
+            label: uninstall litmus
+            description: Uninstall litmus if no more test to run
+            mapping: manifest.spec.template.spec.containers[0].env[8].value
+            defaultValue: "false"             
         manifest:
           apiVersion: batch/v1
           kind: Job
@@ -269,9 +326,15 @@ job:
                       - name: TOTAL_CHAOS_DURATION
                         value: "$(CHAOS_DURATION)"        
                       - name: CPU_CORES
-                        value: "$(NUMBER_OF_CPU_CORES)"    
+                        value: "$(NUMBER_OF_CPU_CORES)"   
+                      - name: CHAOS_INJECT_COMMAND
+                        value: "$(CHAOS_INJECT_COMMAND)"   
+                      - name: CHAOS_KILL_COMMAND
+                        value: "$(CHAOS_KILL_COMMAND)"   
                       - name: TARGET_CONTAINER
                         value: "$(TARGET_CONTAINER)"
+                      - name: UNINSTALL_LITMUS
+                        value: "$(UNINSTALL_LITMUS_ON_COMPLETION)"                           
                       - name: EXPERIMENT_NAME
                         value: "pod-cpu-hog"                          
                     command: ["/bin/bash"]
@@ -284,7 +347,7 @@ job:
         cloudProvider: kubernetes
         account: spinnaker
         credentials: spinnaker
-        application: hello
+        application: litmuschaos
         waitForCompletion: true
         parameters:
           - name: INSTALL_LITMUS
@@ -307,16 +370,26 @@ job:
             description: The time duration for chaos insertion (in sec)	
             mapping: manifest.spec.template.spec.containers[0].env[3].value
             defaultValue: "30"
+          - name: CHAOS_KILL_COMMAND
+            label: chaos kill command
+            description: Kills the chaos process inside the target container	
+            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            defaultValue: "\"kill -9 $(ps afx | grep \"[md5sum] /dev/zero\" | awk '{print$1}' | tr '\n' ' ')\""            
           - name: AMOUNT_OF_MEMORY_CONSUMPTION
             label: Memory consumption
             description: Amount of memory consumption in mb (upto 2500mb)	
-            mapping: manifest.spec.template.spec.containers[0].env[4].value
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
             defaultValue: "500"
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of the container subjected to CPU stress
-            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            mapping: manifest.spec.template.spec.containers[0].env[6].value
             defaultValue: "hello"
+          - name: UNINSTALL_LITMUS_ON_COMPLETION
+            label: uninstall litmus
+            description: Uninstall litmus if no more test to run
+            mapping: manifest.spec.template.spec.containers[0].env[7].value
+            defaultValue: "false"             
         manifest:
           apiVersion: batch/v1
           kind: Job
@@ -338,11 +411,15 @@ job:
                       - name: APP_LABEL
                         value: $(APPLICATION_LABEL)
                       - name: TOTAL_CHAOS_DURATION
-                        value: "$(CHAOS_DURATION)"        
+                        value: "$(CHAOS_DURATION)"
+                      - name: CHAOS_KILL_COMMAND
+                        value: "$(CHAOS_KILL_COMMAND)"                         
                       - name: MEMORY_CONSUMPTION
                         value: "$(AMOUNT_OF_MEMORY_CONSUMPTION)"
                       - name: TARGET_CONTAINER
                         value: "$(TARGET_CONTAINER)"
+                      - name: UNINSTALL_LITMUS
+                        value: "$(UNINSTALL_LITMUS_ON_COMPLETION)"                           
                       - name: EXPERIMENT_NAME
                         value: "pod-memory-hog"                        
                     command: ["/bin/bash"]
@@ -355,7 +432,7 @@ job:
         cloudProvider: kubernetes
         account: spinnaker
         credentials: spinnaker
-        application: hello
+        application: litmuschaos
         waitForCompletion: true
         parameters:
           - name: INSTALL_LITMUS
@@ -383,11 +460,26 @@ job:
             description: The container runtime interface for the cluster
             mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "containerd"
+          - name: SOCKET_PATH
+            label: socket path
+            description: Provide the socket file path, applicable only for containerd runtime
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            defaultValue: "'/run/containerd/containerd.sock'"              
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of container which is subjected to network corruption.
-            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            mapping: manifest.spec.template.spec.containers[0].env[6].value
             defaultValue: "hello"
+          - name: NETWORK_INTERFACE
+            label: Network Interface
+            description: Name of ethernet interface considered for shaping traffic.
+            mapping: manifest.spec.template.spec.containers[0].env[7].value
+            defaultValue: "'eth0'"
+          - name: UNINSTALL_LITMUS_ON_COMPLETION
+            label: uninstall litmus
+            description: Uninstall litmus if no more test to run
+            mapping: manifest.spec.template.spec.containers[0].env[8].value
+            defaultValue: "false"             
         manifest:
           apiVersion: batch/v1
           kind: Job
@@ -412,8 +504,14 @@ job:
                         value: "$(CHAOS_DURATION)"   
                       - name: CONTAINER_RUNTIME
                         value: "$(CONTAINER_RUNTIME)"   
+                      - name: SOCKET_PATH
+                        value: "$(SOCKET_PATH)"
                       - name: TARGET_CONTAINER
                         value: "$(TARGET_CONTAINER)"
+                      - name: NETWORK_INTERFACE
+                        value: "$(NETWORK_INTERFACE)"                        
+                      - name: UNINSTALL_LITMUS
+                        value: "$(UNINSTALL_LITMUS_ON_COMPLETION)"                           
                       - name: EXPERIMENT_NAME
                         value: "pod-network-corruption"                      
                     command: ["/bin/bash"]
@@ -426,7 +524,7 @@ job:
         cloudProvider: kubernetes
         account: spinnaker
         credentials: spinnaker
-        application: hello
+        application: litmuschaos
         waitForCompletion: true
         parameters:
           - name: INSTALL_LITMUS
@@ -454,11 +552,31 @@ job:
             description: The container runtime interface for the cluster
             mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "containerd"
+          - name: SOCKET_PATH
+            label: socket path
+            description: Provide the socket file path, applicable only for containerd runtime
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            defaultValue: "'/run/containerd/containerd.sock'"              
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of container which is subjected to network duplication.
-            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            mapping: manifest.spec.template.spec.containers[0].env[6].value
             defaultValue: "hello"
+          - name: NETWORK_INTERFACE
+            label: Network Interface
+            description: Name of ethernet interface considered for shaping traffic.
+            mapping: manifest.spec.template.spec.containers[0].env[7].value
+            defaultValue: "'eth0'"   
+          - name: NETWORK_PACKET_DUPLICATION_PERCENTAGE
+            label: Network packet duplication percentage
+            description: The packet duplication in percentage.
+            mapping: manifest.spec.template.spec.containers[0].env[8].value
+            defaultValue: "'100'"  
+          - name: UNINSTALL_LITMUS_ON_COMPLETION
+            label: uninstall litmus
+            description: Uninstall litmus if no more test to run
+            mapping: manifest.spec.template.spec.containers[0].env[9].value
+            defaultValue: "false"             
         manifest:
           apiVersion: batch/v1
           kind: Job
@@ -483,8 +601,16 @@ job:
                         value: "$(CHAOS_DURATION)"   
                       - name: CONTAINER_RUNTIME
                         value: "$(CONTAINER_RUNTIME)"   
+                      - name: SOCKET_PATH
+                        value: "$(SOCKET_PATH)"                        
                       - name: TARGET_CONTAINER
                         value: "$(TARGET_CONTAINER)"
+                      - name: NETWORK_INTERFACE
+                        value: "$(NETWORK_INTERFACE)"     
+                      - name: NETWORK_PACKET_DUPLICATION_PERCENTAGE
+                        value: "$(NETWORK_PACKET_DUPLICATION_PERCENTAGE)"                                               
+                      - name: UNINSTALL_LITMUS
+                        value: "$(UNINSTALL_LITMUS_ON_COMPLETION)"                           
                       - name: EXPERIMENT_NAME
                         value: "pod-network-duplication"                           
                     command: ["/bin/bash"]
@@ -497,7 +623,7 @@ job:
         cloudProvider: kubernetes
         account: spinnaker
         credentials: spinnaker
-        application: hello
+        application: litmuschaos
         waitForCompletion: true
         parameters:
           - name: INSTALL_LITMUS
@@ -525,11 +651,31 @@ job:
             description: The container runtime interface for the cluster
             mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "containerd"
+          - name: SOCKET_PATH
+            label: socket path
+            description: Provide the socket file path, applicable only for containerd runtime
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            defaultValue: "'/run/containerd/containerd.sock'"              
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of container which is subjected to network latency.
-            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            mapping: manifest.spec.template.spec.containers[0].env[6].value
             defaultValue: "hello"
+          - name: NETWORK_INTERFACE
+            label: Network Interface
+            description: Name of ethernet interface considered for shaping traffic.
+            mapping: manifest.spec.template.spec.containers[0].env[7].value
+            defaultValue: "'eth0'" 
+          - name: NETWORK_LATENCY
+            label: Network Latency
+            description: The latency/delay in milliseconds.
+            mapping: manifest.spec.template.spec.containers[0].env[8].value
+            defaultValue: "'60000'"
+          - name: UNINSTALL_LITMUS_ON_COMPLETION
+            label: uninstall litmus
+            description: Uninstall litmus if no more test to run
+            mapping: manifest.spec.template.spec.containers[0].env[9].value
+            defaultValue: "false"              
         manifest:
           apiVersion: batch/v1
           kind: Job
@@ -554,8 +700,16 @@ job:
                         value: "$(CHAOS_DURATION)"   
                       - name: CONTAINER_RUNTIME
                         value: "$(CONTAINER_RUNTIME)"   
+                      - name: SOCKET_PATH
+                        value: "$(SOCKET_PATH)"                        
                       - name: TARGET_CONTAINER
                         value: "$(TARGET_CONTAINER)"
+                      - name: NETWORK_INTERFACE
+                        value: "$(NETWORK_INTERFACE)" 
+                      - name: NETWORK_LATENCY
+                        value: "$(NETWORK_LATENCY)"                                                                             
+                      - name: UNINSTALL_LITMUS
+                        value: "$(UNINSTALL_LITMUS_ON_COMPLETION)"                           
                       - name: EXPERIMENT_NAME
                         value: "pod-network-latency"                          
                     command: ["/bin/bash"]
@@ -568,7 +722,7 @@ job:
         cloudProvider: kubernetes
         account: spinnaker
         credentials: spinnaker
-        application: hello
+        application: litmuschaos
         waitForCompletion: true
         parameters:
           - name: INSTALL_LITMUS
@@ -596,11 +750,31 @@ job:
             description: The container runtime interface for the cluster
             mapping: manifest.spec.template.spec.containers[0].env[4].value
             defaultValue: "containerd"
+          - name: SOCKET_PATH
+            label: socket path
+            description: Provide the socket file path, applicable only for containerd runtime
+            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            defaultValue: "'/run/containerd/containerd.sock'"              
           - name: TARGET_CONTAINER
             label: Target Container
             description: Name of container which is subjected to network loss.
-            mapping: manifest.spec.template.spec.containers[0].env[5].value
+            mapping: manifest.spec.template.spec.containers[0].env[6].value
             defaultValue: "hello"
+          - name: NETWORK_INTERFACE
+            label: Network Interface
+            description: Name of ethernet interface considered for shaping traffic.
+            mapping: manifest.spec.template.spec.containers[0].env[7].value
+            defaultValue: "'eth0'"
+          - name: NETWORK_PACKET_LOSS_PERCENTAGE
+            label: Network packet loss percentage
+            description: The packet loss in percentage.
+            mapping: manifest.spec.template.spec.containers[0].env[8].value
+            defaultValue: "'100'"  
+          - name: UNINSTALL_LITMUS_ON_COMPLETION
+            label: uninstall litmus
+            description: Uninstall litmus if no more test to run
+            mapping: manifest.spec.template.spec.containers[0].env[9].value
+            defaultValue: "false"              
         manifest:
           apiVersion: batch/v1
           kind: Job
@@ -625,45 +799,19 @@ job:
                         value: "$(CHAOS_DURATION)"   
                       - name: CONTAINER_RUNTIME
                         value: "$(CONTAINER_RUNTIME)"   
+                      - name: SOCKET_PATH
+                        value: "$(SOCKET_PATH)"                        
                       - name: TARGET_CONTAINER
                         value: "$(TARGET_CONTAINER)"
+                      - name: NETWORK_INTERFACE
+                        value: "$(NETWORK_INTERFACE)"  
+                      - name: NETWORK_PACKET_LOSS_PERCENTAGE
+                        value: "$(NETWORK_PACKET_LOSS_PERCENTAGE)"                                                   
+                      - name: UNINSTALL_LITMUS
+                        value: "$(UNINSTALL_LITMUS_ON_COMPLETION)"                           
                       - name: EXPERIMENT_NAME
                         value: "pod-network-loss"                          
                     command: ["/bin/bash"]
                     args:
                     - -c 
                     - ./experiment_entrypoint.sh
-      - label: Uninstall-Litmus
-        type: ChaosOperatorRemove
-        description: Uninstall litmus and its components
-        cloudProvider: kubernetes
-        account: spinnaker
-        credentials: spinnaker
-        application: hello
-        waitForCompletion: true
-        parameters:
-          - name: APPLICATION_NAMESPACE
-            label: Namespace of AUT
-            description: Namespace where chaos will occur
-            mapping: manifest.spec.template.spec.containers[0].env[0].value
-            defaultValue: "spinnaker"
-        manifest:
-          apiVersion: batch/v1
-          kind: Job
-          metadata:
-            name: uninstallation
-          spec:
-            backoffLimit: 0
-            template:
-              spec:
-                restartPolicy: Never
-                containers: 
-                  - name: uninstallation
-                    image: mayadataio/chaos-ci-lib:ci
-                    env:
-                      - name: APP_NS
-                        value: $(APPLICATION_NAMESPACE)
-                    command: ["/bin/bash"]
-                    args:
-                    - -c 
-                    - ./uninstall-litmus


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>

- This PR is for adding some spinnaker templates for running litmus pod level experiments:

_The experiments added are:_ 

  - [X]  Pod Delete
  - [X] Container Kill
  - [X] Disk Fill 
  - [X] Pod Network Loss  
  - [X] Pod Network Latency
  - [X] Pod Network Duplication
  - [X] Pod Network Corruption

- Updated the suite with all the above experiments. 
